### PR TITLE
Prevent error message when there are no datasources.

### DIFF
--- a/symphony/lib/toolkit/class.datasourcemanager.php
+++ b/symphony/lib/toolkit/class.datasourcemanager.php
@@ -97,6 +97,7 @@ class DatasourceManager implements FileResource
     {
         $result = array();
         $structure = General::listStructure(DATASOURCES, '/data.[\\w-]+.php/', false, 'ASC', DATASOURCES);
+        $structure['filelist'] = $structure['filelist'] ?? array();
 
         if (is_array($structure['filelist']) && !empty($structure['filelist'])) {
             foreach ($structure['filelist'] as $f) {


### PR DESCRIPTION
The datasources index page gives an error message when there are no datasources, using PHP 8.4.11.
<img width="1028" height="1304" alt="Firefox_Screenshot_2025-12-07T12-27-01 325Z" src="https://github.com/user-attachments/assets/a1a2fa7e-53b7-4aaa-b04a-1641b13bbc3c" />
