### PR TITLE
Update handle creation: Strip emojis reliably

### DIFF
--- a/symphony/lib/toolkit/class.general.php
+++ b/symphony/lib/toolkit/class.general.php
@@ -337,7 +337,9 @@ class General
 
         // Remove emojis and symbol-type unicode characters early
         // by tiloschroeder
-        $string = preg_replace('/[\p{So}\p{Cn}\x{1F600}-\x{1F6FF}]+/u', '', $string);
+        // Allow only ASCII characters—the safest method, without checking PHP versions or using loops.
+        // Works reliably in PHP 7.1–8.5
+        $string = preg_replace('/[^a-zA-Z0-9\-]+/', '', $string);
 
         // Trim to word limit
         if ($max_length > 0) {


### PR DESCRIPTION
- Recognizes emojis only, not ZWJs (Zero Width Joiners) or emoji modifiers (light skin tone, dark skin tone).  
 Modifiers are still removed in PHP 7.1 and 7.2. They are displayed in later versions.  
 `$string = preg_replace('/[\p{So}\p{Cn}\x{1F600}-\x{1F6FF}]+/u', '', $string);`
- PCRE2 Unicode properties are supported and executed only starting with PHP 8.2.  
  In earlier versions, an empty string is returned.  
  `$string = preg_replace('/[\p{Extended_Pictographic}\p{Emoji_Component}\x{200D}\x{FE0F}]/u', '', $string);`
- Allow only ASCII characters is the safest method, without checking PHP versions or using loops. Works reliably in PHP 7.1–8.5