### PR TITLE
Deprecated E_STRICT constant

### DIFF
--- a/symphony/lib/boot/bundle.php
+++ b/symphony/lib/boot/bundle.php
@@ -5,7 +5,7 @@
      */
 
     // Set appropriate error reporting:
-    error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
+    error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED);
 
     // Turn off old-style magic:
     ini_set('magic_quotes_runtime', false);


### PR DESCRIPTION
- `E_STRICT` is unused, and has been deprecated as of PHP 8.4.0.