### PR TITLE
Fix: Reset libxml internal error state after XSLT processing

### DIFF
--- a/symphony/lib/toolkit/class.xsltprocess.php
+++ b/symphony/lib/toolkit/class.xsltprocess.php
@@ -181,6 +181,9 @@ class XsltProcess
 
         }
 
+        libxml_clear_errors();
+        libxml_use_internal_errors(false);
+
         // Set parameters when defined
         if (!empty($parameters)) {
             General::flattenArray($parameters);


### PR DESCRIPTION
Ensure that `libxml_use_internal_errors(false)` is always restored after XSLT processing in `/symphony/lib/toolkit/class.xsltprocess.php` (around line 160).

Previously, the internal error mode remained enabled when no errors occurred, causing inconsistent XML parsing behavior depending on the environment.

This could lead to frontend errors when processing certain characters, e.g.:

- `&` → xmlParseEntityRef: no name
- `<` → StartTag: invalid element name

The error state is now always cleared and reset, ensuring deterministic behavior across environments.