### PR TITLE
New extension Subresource Integrity

### DIFF
--- a/extensions/sri/LICENCE.txt
+++ b/extensions/sri/LICENCE.txt
@@ -1,0 +1,28 @@
+All source code included in this Symphony Extension
+is, unless otherwise specified, released under the MIT license as
+follows:
+
+----- begin license block -----
+
+Copyright 2016-2019 Deux Huit Huit inc.
+Copyright since 2026 Sym8
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+----- end license block -----

--- a/extensions/sri/README.md
+++ b/extensions/sri/README.md
@@ -1,0 +1,78 @@
+# Subresource Integrity
+
+A simple way to compute base64 encoded sha (256, 384, 512) of assets files used in `link` and `script` tags.
+
+- You specify the files in a xml file (`manifest/sri.xml`)
+- The results are in the provided [data source](#data-source)
+
+See <https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity> for more details on SRI.
+
+## Requirements
+
+- Symphony CMS version 2.6.0 and up (as of the day of the last release of this extension)
+
+## Installation
+
+- `git clone` / download and unpack the tarball file
+- Put into the extension directory
+- Enable/install just like any other extension
+
+## How to use
+
+1. Create the file `manifest/sri.xml`
+2. [Fill it up](#srixml-file)
+3. Add the SRI data sources on pages that needs it.
+4. [Set the `integrity` attribute accordingly](#integrity-attribute)
+
+### `sri.xml` file
+
+This file must contains a list of all files where the integrity hash needs to be computed. The file must follow this schema:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<files hash="sha512">
+    <file>symphony/assets/css/symphony.min.css</file>
+    <file hash="sha256">symphony/assets/js/symphony.min.js</file>
+</files>
+```
+
+File path are relative to the `DOCROOT` and must never start with a trailing slash. Hash algorithm can be specified globally by setting the `hash` attribute of the root level tag. Hash algorithm can also be specified on a a per file basis, using the same `hash` attribute.
+
+### `integrity` attribute
+
+Using the provided data source, you can output the right value with this piece of either one of:
+
+```xslt
+<!-- Using the filename attribute -->
+<script src="/path/to/file.ext" integrity="{/data/sri/file[@filename='file.ext']/@integrity}"></script>
+<!-- Using the complete path -->
+<link href="/path/to/file.ext" integrity="{/data/sri/file[.='path/to/file.ext']/@integrity}" />
+```
+
+### Data Source
+
+The data source outputs some useful information. Also, any exception thrown in the data source execution process are logged into Symphony's logs.
+
+```xml
+<sri>
+    <file filename="symphony.min.css" hash="sha512" integrity="sha512-0UfXWfRg5GzU/l6VXUKRMl3TFmz0FijSoJMt3vmfjwTkYztMDWqpvFZ4F4eMY9c5C+/n49cuFya8A0vN95deug==" cache="miss-saved">symphony/assets/css/symphony.min.css</file>
+    <file filename="symphony.min.js" hash="sha256" integrity="sha256-8jb0A0Ei0W+is2NHkiAeUdWDrXPhYQeoFGF6ljIKCKs=" cache="hit">symphony/assets/js/symphony.min.js</file>
+</sri>
+```
+
+- `filename` contains the name of the file
+- `hash` contains the hash algorithm used
+- `integrity` contains the value set in the `integrity` attribute
+- `cache` contains info about the cache. Possible values are
+    + `miss`: Not found in cache nor was the cache updated
+    + `saved-miss`: Not found in cache but saved for future use
+    + `hit`: Integrity value found in cache
+    + `disabled`: Cache is disabled
+
+### Caching
+
+This extension uses Symphony's database driven cache provider in order to prevent reading each file and computing the hash on each request. The cache ttl is 30 days, but the data source checks the file modified time before using any value from the cache. If the file changed, the hash is updated.
+
+## License
+
+[MIT](http://deuxhuithuit.mit-license.org)

--- a/extensions/sri/data-sources/data.sri.php
+++ b/extensions/sri/data-sources/data.sri.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Copyright: Deux Huit Huit 2016
+ * LICENCE: MIT https://deuxhuithuit.mit-license.org;
+ */
+
+if(!defined("__IN_SYMPHONY__")) die("<h2>Error</h2><p>You cannot directly access this file</p>");
+
+require_once TOOLKIT . '/class.datasource.php';
+require_once TOOLKIT . '/class.entrymanager.php';
+require_once FACE . '/interface.datasource.php';
+
+class datasourceSri extends DataSource
+{
+    public $dsFilesPath;
+    public $dsCache = true;
+    private $dsCacheProvider;
+    public $dsCacheNamespace = 'sri';
+    public $dsCacheTTL = 43200; // 60 * 24 * 30;
+
+    public function __construct()
+    {
+        $this->dsFilesPath = MANIFEST . '/sri.xml';
+        $this->dsCacheProvider = new Cacheable(Symphony::Database());
+        if (defined('HTTP_HOST')) {
+            $this->dsCacheNamespace .= '-' . HTTP_HOST;
+        }
+    }
+
+    /**
+     * About this data source
+     */
+    public function about()
+    {
+        return array(
+            'name' => __('SRI'),
+                     'author' => array(
+                         'name' => 'Sym8',
+                         'website' => 'https://sym8.io/'
+                     ),
+                     'version' => '1.2.0',
+                     'release-date' => '2026-03-31'
+        );
+    }
+
+    /**
+     * Disallow data source parsing
+     */
+    public function allowEditorToParse()
+    {
+        return false;
+    }
+
+    /**
+     * This function generates a list of month and weekday names for each language provided.
+     */
+    public function execute(array &$param_pool=NULL)
+    {
+        $result = new XMLElement('sri');
+        try {
+            $files = $this->getFiles();
+            foreach ($files as $file) {
+                $xmlfile = new XMLElement('file');
+                $cache = $this->dsCache ? 'hit' : 'disabled';
+                $filepath = DOCROOT . '/' . $file['file'];
+                $integrity = $this->getCachedIntegrity($file, $filepath);
+                if (!$integrity) {
+                    $cache = $this->dsCache ? 'miss' : 'disabled';
+
+                    $integrity = $this->computeIntegrity($file, $filepath);
+
+                    if (!$integrity) {
+                        $result->appendChild(new XMLElement('error', 'Could not hash `' . $filepath . '`'));
+                        continue;
+                    }
+
+                    if ($this->saveIntegrityToCache($file, $filepath, $integrity)) {
+                        $cache = 'saved-miss';
+                    }
+                }
+                $xmlfile->setAttribute('filename', basename($file['file']));
+                $xmlfile->setAttribute('hash', $file['hash']);
+                $xmlfile->setAttribute('integrity', $integrity);
+                $xmlfile->setAttribute('cache', $cache);
+                $xmlfile->setValue($file['file']);
+
+                $result->appendChild($xmlfile);
+            }
+        }
+        catch (Exception $ex) {
+            Symphony::Log()->pushExceptionToLog($ex, true);
+            $result->appendChild(new XMLElement('error', General::wrapInCDATA($ex->getMessage())));
+        }
+        return $result;
+    }
+
+    private function getFiles()
+    {
+        if (!@file_exists($this->dsFilesPath)) {
+            return array();
+        }
+        $files = array();
+        $xml = @simplexml_load_file($this->dsFilesPath);
+        if (!$xml) {
+            throw new Exception('Could not load xml file');
+        }
+        $defaultHash = (string)current($xml->xpath('/*/@hash'));
+        if (empty($defaultHash)) {
+            $defaultHash = 'sha384';
+        }
+        $xmlfiles = $xml->xpath('/*/file');
+        foreach ($xmlfiles as $file) {
+            $fileHash = (string)current($file->xpath('@hash'));
+            if (empty($fileHash)) {
+                $fileHash = $defaultHash;
+            }
+            $files[] = array(
+                'file' => (string)$file,
+                             'hash' => $fileHash,
+                             'namespace' => $this->dsCacheNamespace,
+            );
+        }
+        return $files;
+    }
+
+    private function computeIntegrity(array $file, $filepath)
+    {
+        if (!@file_exists($filepath)) {
+            return null;
+        }
+        $hash = @hash_file($file['hash'], $filepath, true);
+        if (!$hash) {
+            return null;
+        }
+        return $file['hash'] . '-' . base64_encode($hash);
+    }
+
+    private function createCacheKey(array $file)
+    {
+        return md5(implode('.', array_values($file)));
+    }
+
+    private function getCachedIntegrity(array $file, $filepath)
+    {
+        if (!$this->dsCache) {
+            return null;
+        }
+        if (!@file_exists($filepath)) {
+            return null;
+        }
+        $key = $this->createCacheKey($file);
+        $cache = $this->dsCacheProvider->read($key);
+        if (!$cache || !isset($cache['creation'])) {
+            return null;
+        }
+        clearstatcache();
+        if ($cache['creation'] < filemtime($filepath)) {
+            return null;
+        }
+        return $cache['data'];
+    }
+
+    private function saveIntegrityToCache(array $file, $filepath, $integrity)
+    {
+        if (!$this->dsCache) {
+            return false;
+        }
+        $key = $this->createCacheKey($file);
+        if (empty($integrity)) {
+            $this->dsCacheProvider->delete($key, $this->dsCacheNamespace);
+            return false;
+        }
+        return $this->dsCacheProvider->write($key, $integrity, $this->dsCacheTTL, $this->dsCacheNamespace);
+    }
+}

--- a/extensions/sri/extension.driver.php
+++ b/extensions/sri/extension.driver.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright: Deux Huit Huit 2016
+ * LICENCE: MIT https://deuxhuithuit.mit-license.org;
+ */
+
+if(!defined("__IN_SYMPHONY__")) die("<h2>Error</h2><p>You cannot directly access this file</p>");
+
+/**
+ *
+ * @author Deux Huit Huit
+ * https://deuxhuithuit.com/
+ *
+ */
+class extension_sri extends Extension
+{
+
+    /**
+     * Name of the extension
+     * @var string
+     */
+    const EXT_NAME = 'Subresource Integrity';
+
+    /* ********* INSTALL/UPDATE/UNINSTALL ******* */
+
+    /**
+     * Creates the table needed for the settings of the field
+     */
+    public function install()
+    {
+        return true;
+    }
+
+    /**
+     * This method will update the extension according to the
+     * previous and current version parameters.
+     * @param string $previousVersion
+     */
+    public function update($previousVersion = false)
+    {
+        $ret = true;
+
+        if (!$previousVersion) {
+            $previousVersion = '0.0.1';
+        }
+
+        // less than 0.0.1
+        if ($ret && version_compare($previousVersion, '0.0.1', '<')) {
+
+        }
+
+        return $ret;
+    }
+
+    /**
+     * Drops the table needed for the settings of the field
+     */
+    public function uninstall()
+    {
+        return true;
+    }
+
+}

--- a/extensions/sri/extension.meta.xml
+++ b/extensions/sri/extension.meta.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extension id="sri" status="released" xmlns="http://getsymphony.com/schemas/extension/1.0">
+  <name>Subresource Integrity</name>
+  <description>
+    A simple way to compute base64 encoded sha (256, 384, 512) of assets files used in `link` and `script` tags.
+  </description>
+  <repo type="github">https://github.com/sym8-io/sri</repo>
+  <url type="issues">https://github.com/sym8-io/sri/issues</url>
+  <types>
+    <type>Subresource</type>
+    <type>Integrity</type>
+    <type>Security</type>
+  </types>
+  <authors>
+    <author>
+      <name github="Sym8-io">Sym8</name>
+      <website>https://sym8.io/</website>
+    </author>
+  </authors>
+  <dependencies>
+    <!-- None -->
+  </dependencies>
+  <releases>
+    <release version="1.2.1" date="2026-03-31" min="2.6.0" max="2.x.x">
+      - Update Readme
+    </release>
+    <release version="1.2.0" date="2026-03-31" min="2.6.0" max="2.x.x">
+      - Extension is now part of Sym8
+      - PSR-12 formatting
+    </release>
+    <release version="1.1.0" date="2019-04-23" min="2.6.0" max="2.x.x">
+      - Add support for running multiple host with the same database
+    </release>
+    <release version="1.0.2" date="2016-09-23" min="2.6.0" max="2.x.x">
+      - Prevent logs from filling up when file does not exists
+    </release>
+    <release version="1.0.1" date="2016-04-21" min="2.6.0" max="2.x.x">
+      - Use `hash_file()` instead of `hash(file_get_contents())`
+    </release>
+    <release version="1.0.0" date="2016-04-20" min="2.6.0" max="2.x.x">
+      - First release
+    </release>
+  </releases>
+</extension>

--- a/install/lib/class.installer.php
+++ b/install/lib/class.installer.php
@@ -842,6 +842,7 @@ class Installer extends Administration
             'health_check',
             'duplicate_section',
             'xcachelite',
+            'sri',
         );
         $disabled_extensions = array();
         foreach (new DirectoryIterator(EXTENSIONS) as $e) {


### PR DESCRIPTION
- A simple way to compute base64 encoded sha (256, 384, 512) of assets files used in link and script tags.
- The extension is not activated automatically after installation.