### PR TITLE
Add extension "Order Entries" v2.3.11

### DIFF
--- a/extensions/order_entries/extension.meta.xml
+++ b/extensions/order_entries/extension.meta.xml
@@ -1,94 +1,99 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <extension id="order_entries" status="released" xmlns="http://symphony-cms.com/schemas/extension/1.0">
-    <name>Order Entries</name>
-    <description lang="en">Allow drag-and-drop re-ordering of entries.</description>
-    <repo type="github">https://github.com/sym8-io/sym8</repo>
-    <types>
-        <type>Workflow</type>
-        <type>Field</type>
-        <type>Ordering</type>
-    </types>
-    <authors>
-        <author>
-            <name github="sym8-io">Sym8</name>
-            <website>https://sym8.io</website>
-        </author>
-        <author>
-            <name github="nickdunn" symphony="nickdunn" twitter="nickdunn">Nick Dunn</name>
-            <website>http://nick-dunn.co.uk</website>
-        </author>
-    </authors>
-    <releases>
-        <release version="2.3.10" date="2025-05-16" min="2.5" max="2.x.x">
-            - Change database charset
-        </release>
-        <release version="2.3.9" date="2019-01-22" min="2.5" max="2.x.x">
-            - Fix error when the field is the first visible (#86)
-        </release>
-        <release version="2.3.8" date="2017-11-09" min="2.5" max="2.x.x">
-            - Prevent error when no fields are set (#85)
-        </release>
-        <release version="2.3.7" date="2016-11-17" min="2.5" max="2.x.x">
-            - Removed inline script injection (#83)
-        </release>
-        <release version="2.3.6" date="2016-08-09" min="2.5" max="2.x.x">
-            - Supported on PHP 7
-            - Bug fixes (#73 and #77)
-        </release>
-        <release version="2.3.5" date="2016-07-29" min="2.5" max="2.x.x">
-            - Fix broken save on large data sets: Use POST instead of GET
-        </release>
-        <release version="2.3.4" date="2016-03-06" min="2.5" max="2.x.x">
-            - Fix the broken "Hide on publish pages" that always hid the field (#78)
-            - Added a LICENCE.txt file
-        </release>
-        <release version="2.3.3" date="2016-01-05" min="2.5" max="2.6.x">
-            - Fix bug with core API: Widget::wrapFormElementWithError is now Widget::Error
-            - Replace mistyped delegate with new one
-        </release>
-        <release version="2.3.2" date="2015-11-20" min="2.5" max="2.6.x">
-            - Fix bug where value was also being set for null filters
-        </release>
-        <release version="2.3.1" date="2015-10-07" min="2.5" max="2.6.x">
-            - Bug fixes (#69, #72, #73)
-        </release>
-        <release version="2.3.0" date="2015-09-01" min="2.5" max="2.6.x">
-            - Added filtered ordering
-            - Bug fixes
-        </release>
-        <release version="2.2.1" date="2015-01-26" min="2.5" max="2.6.x">
-            - Fix entry selection
-        </release>
-        <release version="2.2.0" date="2015-01-22" min="2.5" max="2.6.x">
-            - Add contextual Ordering using backend/frontend filters
-            - Add Disable Pagination Option
-        </release>
-        <release version="2.1.3" date="2014-07-13" min="2.4">
-            - Fixed the login page being crashed
-        </release>
-        <release version="2.1.2" date="2014-06-21" min="2.4">
-            - Fixed invalid meta XML
-        </release>
-        <release version="2.1.1" date="2014-06-20" min="2.4">
-            - Fixed table selection
-        </release>
-        <release version="2.1.0" date="2014-06-12" min="2.4">
-            - Fixed incorrect version number
-        </release>
-        <release version="2.0.1" date="2014-04-16" min="2.4">
-            - Minor fixes
-            - Added custom delegated pre and post ordering
-        </release>
-        <release version="2.0.0" date="2014-04-15" min="2.4">
-            - Symphony 2.4 compatibility
-            - Fixed pagination maximum rows
-            - Fixed force sort that now automatically sets sorting
-        </release>
-        <release version="1.10.1" date="2012-03-11" min="2.3.x" />
-        <release version="1.10.0" date="2012-03-09" min="2.3.x" />
-        <release version="1.9.8" date="2011-12-19" min="2.2.2" max="2.2.x" />
-        <release version="1.9.7" date="2011-10-12" min="2.2.2" />
-        <release version="1.9.6" date="2011-02-16" min="2.2" />
-        <release version="1.9.5" date="2011-05-21" min="2.0.3" max="2.1.x" />
-    </releases>
+  <name>Order Entries</name>
+  <description lang="en">Allow drag-and-drop re-ordering of entries.</description>
+  <repo type="github">https://github.com/sym8-io/sym8</repo>
+  <types>
+    <type>Workflow</type>
+    <type>Field</type>
+    <type>Ordering</type>
+  </types>
+  <authors>
+    <author>
+      <name github="sym8-io">Sym8</name>
+      <website>https://sym8.io</website>
+    </author>
+    <author>
+      <name github="nickdunn" symphony="nickdunn" twitter="nickdunn">Nick Dunn</name>
+      <website>http://nick-dunn.co.uk</website>
+    </author>
+  </authors>
+  <releases>
+    <release version="2.3.11" date="2026-04-26" min="2.5" max="2.x.x">
+      - The field is now generated as an input type `number`
+      - The generated front-end form markup follows a consistent format for all fields
+      - If "Hide on publish page" is enabled for the field, it is not generated in the front-end form markup
+    </release>
+    <release version="2.3.10" date="2025-05-16" min="2.5" max="2.x.x">
+      - Change database charset
+    </release>
+    <release version="2.3.9" date="2019-01-22" min="2.5" max="2.x.x">
+      - Fix error when the field is the first visible (#86)
+    </release>
+    <release version="2.3.8" date="2017-11-09" min="2.5" max="2.x.x">
+      - Prevent error when no fields are set (#85)
+    </release>
+    <release version="2.3.7" date="2016-11-17" min="2.5" max="2.x.x">
+      - Removed inline script injection (#83)
+    </release>
+    <release version="2.3.6" date="2016-08-09" min="2.5" max="2.x.x">
+      - Supported on PHP 7
+      - Bug fixes (#73 and #77)
+    </release>
+    <release version="2.3.5" date="2016-07-29" min="2.5" max="2.x.x">
+      - Fix broken save on large data sets: Use POST instead of GET
+    </release>
+    <release version="2.3.4" date="2016-03-06" min="2.5" max="2.x.x">
+      - Fix the broken "Hide on publish pages" that always hid the field (#78)
+      - Added a LICENCE.txt file
+    </release>
+    <release version="2.3.3" date="2016-01-05" min="2.5" max="2.6.x">
+      - Fix bug with core API: Widget::wrapFormElementWithError is now Widget::Error
+      - Replace mistyped delegate with new one
+    </release>
+    <release version="2.3.2" date="2015-11-20" min="2.5" max="2.6.x">
+      - Fix bug where value was also being set for null filters
+    </release>
+    <release version="2.3.1" date="2015-10-07" min="2.5" max="2.6.x">
+      - Bug fixes (#69, #72, #73)
+    </release>
+    <release version="2.3.0" date="2015-09-01" min="2.5" max="2.6.x">
+      - Added filtered ordering
+      - Bug fixes
+    </release>
+    <release version="2.2.1" date="2015-01-26" min="2.5" max="2.6.x">
+      - Fix entry selection
+    </release>
+    <release version="2.2.0" date="2015-01-22" min="2.5" max="2.6.x">
+      - Add contextual Ordering using backend/frontend filters
+      - Add Disable Pagination Option
+    </release>
+    <release version="2.1.3" date="2014-07-13" min="2.4">
+      - Fixed the login page being crashed
+    </release>
+    <release version="2.1.2" date="2014-06-21" min="2.4">
+      - Fixed invalid meta XML
+    </release>
+    <release version="2.1.1" date="2014-06-20" min="2.4">
+      - Fixed table selection
+    </release>
+    <release version="2.1.0" date="2014-06-12" min="2.4">
+      - Fixed incorrect version number
+    </release>
+    <release version="2.0.1" date="2014-04-16" min="2.4">
+      - Minor fixes
+      - Added custom delegated pre and post ordering
+    </release>
+    <release version="2.0.0" date="2014-04-15" min="2.4">
+      - Symphony 2.4 compatibility
+      - Fixed pagination maximum rows
+      - Fixed force sort that now automatically sets sorting
+    </release>
+    <release version="1.10.1" date="2012-03-11" min="2.3.x" />
+    <release version="1.10.0" date="2012-03-09" min="2.3.x" />
+    <release version="1.9.8" date="2011-12-19" min="2.2.2" max="2.2.x" />
+    <release version="1.9.7" date="2011-10-12" min="2.2.2" />
+    <release version="1.9.6" date="2011-02-16" min="2.2" />
+    <release version="1.9.5" date="2011-05-21" min="2.0.3" max="2.1.x" />
+  </releases>
 </extension>

--- a/extensions/order_entries/fields/field.order_entries.php
+++ b/extensions/order_entries/fields/field.order_entries.php
@@ -321,7 +321,8 @@ Class fieldOrder_Entries extends Field
                     $input = Widget::Input(
                         'fields' . $fieldnamePrefix . '[' . $this->get('element_name') . '][' . $col . '][' . $key . ']' . $fieldnamePostfix,
                         (strlen($value) !== 0 || $col != 'value') ? (string)$value : (string)++$max_position["max"],
-                        ($isHidden  || $col != 'value') ? 'hidden' : 'text'
+                        ($isHidden || $col != 'value') ? 'hidden' : 'number',
+                        ($isHidden || $col != 'value') ? array() : array('step' => '1', 'min' => '1')
                     );
                     $inputs->appendChild($input);
                 }
@@ -335,7 +336,8 @@ Class fieldOrder_Entries extends Field
             $input = Widget::Input(
                 'fields' . $fieldnamePrefix . '[' . $this->get('element_name') . ']' . $fieldnamePostfix,
                 (strlen($value) !== 0 ? (string)$value : (string)++$max_position["max"]),
-                ($this->get('hide') == 'yes') ? 'hidden' : 'text'
+                ($this->get('hide') === 'yes') ? 'hidden' : 'number',
+                ($this->get('hide') === 'yes') ? array() : array('step' => '1', 'min' => '1')
             );
 
             if (!$isHidden) {
@@ -545,6 +547,31 @@ Class fieldOrder_Entries extends Field
     public function getParameterPoolValue(array $data, $entry_id = NULL)
     {
         return $this->getOrderValue($data);
+    }
+
+    public function getExampleFormMarkup()
+    {
+        $isHidden = $this->get('hide');
+
+        if ($isHidden === 'yes') {
+            return null;
+        } else {
+            $fieldId = $this->get('id');
+            $fieldName = $this->get('element_name');
+
+            $div = new XMLElement('div', null, array('class' => 'form-field'));
+            $label = Widget::Label($this->get('label'));
+            $label->setAttribute('for', $fieldName . '-' . $fieldId);
+
+            $input = Widget::input('fields[' . $fieldName . ']', null, 'number', array('step' => '1', 'min' => '1'));
+            $input->setAttribute('id', $fieldName . '-' . $fieldId);
+
+            $div->appendChild($label);
+            $div->appendChild($input);
+
+            return $div;
+        }
+
     }
 
 }


### PR DESCRIPTION
- The field is now generated as an input type `number`
- The generated front-end markup for the field follows a consistent format for all fields
- If "Hide on publish page" is enabled for the field, it is not generated in the front-end form markup