### PR TITLE
Normalize example front-end form markup and fix accessibility issues

### DIFF
--- a/install/installable/field.number.php
+++ b/install/installable/field.number.php
@@ -142,12 +142,12 @@ class FieldNumber extends Field
             'max' => $this->get('max'),
             'step' => $this->get('step') ?: 1
         ]);
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
 
         $label = Widget::label($this->get('label'));
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
             $label->appendChild(new XMLElement('i', __('Optional')));
         }
         $label->appendChild($input);
@@ -166,15 +166,15 @@ class FieldNumber extends Field
         $element = new XMLElement($this->get('element_name'), $value);
 
         // Return additional attributes 'min', 'max' and 'step'
-        if ( $this->get('min') !== null ) {
+        if ($this->get('min') !== null) {
             $element->setAttribute('min', $this->get('min'));
         }
 
-        if ( $this->get('max') !== null ) {
+        if ($this->get('max') !== null) {
             $element->setAttribute('max', $this->get('max'));
         }
 
-        if ( $this->get('step') !== null ) {
+        if ($this->get('step') !== null) {
             $element->setAttribute('step', $this->get('step'));
         }
 
@@ -183,20 +183,32 @@ class FieldNumber extends Field
 
     public function getExampleFormMarkup()
     {
-        $label = new XMLElement('label', $this->get('label'));
+        $fieldId = $this->get('id');
+        $fieldName = $this->get('element_name');
 
-        $input = Widget::input('fields['.$this->get('element_name').']', null, 'number', [
+        $div = new XMLElement('div', null, array('class' => 'form-field'));
+        $label = Widget::Label($this->get('label'));
+        $label->setAttribute('for', $fieldName . '-' . $fieldId);
+        if ($this->get('required') === 'yes') {
+            $mark = new XMLElement('span', '*');
+            $mark->setAttribute('aria-hidden', 'true');
+            $mark->setAttribute('class', 'required-mark');
+            $label->appendChild($mark);
+        }
+        $input = Widget::input('fields[' . $fieldName . ']', null, 'number', [
             'min' => $this->get('min'),
             'max' => $this->get('max'),
             'step' => $this->get('step') ?: 1
         ]);
-        if ( $this->get('required') === 'yes' ) {
+        $input->setAttribute('id', $fieldName . '-' . $fieldId);
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
 
-        $label->appendChild($input);
+        $div->appendChild($label);
+        $div->appendChild($input);
 
-        return $label;
+        return $div;
     }
 
     public function checkPostFieldData($data, &$message, $entry_id = null)
@@ -207,31 +219,31 @@ class FieldNumber extends Field
         $max = $this->get('max');
         $step = $this->get('step');
 
-        if ( $this->get('required') == 'yes' && strlen($data) === 0 ) {
+        if ($this->get('required') == 'yes' && strlen($data) === 0) {
             $message = __('‘%s’ is a required field.', array($this->get('label')));
             return self::__MISSING_FIELDS__;
         }
 
-        if ( strlen($data) > 0 && !is_numeric($data) ) {
+        if (strlen($data) > 0 && !is_numeric($data)) {
             $message = __('Please enter a valid number.');
             return self::__INVALID_FIELDS__;
         }
 
-        if ( is_numeric($data) ) {
+        if (is_numeric($data)) {
 
-            if ( is_numeric($min) && $data < $min ) {
+            if (is_numeric($min) && $data < $min) {
                 $message = __('Number must be greater than or equal to %s.', [$min]);
                 return self::__INVALID_FIELDS__;
             }
 
-            if ( is_numeric($max) && $data > $max ) {
+            if (is_numeric($max) && $data > $max) {
                 $message = __('Number must be less than or equal to %s.', [$max]);
                 return self::__INVALID_FIELDS__;
             }
 
-            if ( is_numeric($step) && $step > 0 ) {
+            if (is_numeric($step) && $step > 0) {
                 $relative = $data - $min;
-                if ( fmod($relative, $step) !== 0.0 ) {
+                if (fmod($relative, $step) !== 0.0) {
                     $message = __('Number must increase in steps of %s starting from %s.', [$step, $min]);
                     return self::__INVALID_FIELDS__;
                 }
@@ -245,7 +257,7 @@ class FieldNumber extends Field
     {
         $status = self::__OK__;
 
-        if ( strlen(trim($data)) == 0 ) return array();
+        if (strlen(trim($data)) == 0) return array();
 
         $result = array(
             'value' => $data
@@ -271,10 +283,10 @@ class FieldNumber extends Field
         $message = $status = null;
         $modes = (object)$this->getImportModes();
 
-        if($mode === $modes->getValue) {
+        if ($mode === $modes->getValue) {
             return $data;
         }
-        else if($mode === $modes->getPostdata) {
+        elseif ($mode === $modes->getPostdata) {
             return $this->processRawFieldData($data, $status, $message, true, $entry_id);
         }
 
@@ -312,7 +324,7 @@ class FieldNumber extends Field
         $modes = (object)$this->getExportModes();
 
         // Export unformatted:
-        if ( $mode === $modes->getUnformatted || $mode === $modes->getPostdata ) {
+        if ($mode === $modes->getUnformatted || $mode === $modes->getPostdata) {
             return isset($data['value'])
                 ? $data['value']
                 : null;
@@ -372,7 +384,7 @@ class FieldNumber extends Field
         $expression = " `t$field_id`.`value` ";
 
         // X to Y support
-        if ( preg_match('/^(-?(?:\d+(?:\.\d+)?|\.\d+)) to (-?(?:\d+(?:\.\d+)?|\.\d+))$/i', $data[0], $match) ) {
+        if (preg_match('/^(-?(?:\d+(?:\.\d+)?|\.\d+)) to (-?(?:\d+(?:\.\d+)?|\.\d+))$/i', $data[0], $match)) {
 
             $joins .= " LEFT JOIN `tbl_entries_data_$field_id` AS `t$field_id` ON (`e`.`id` = `t$field_id`.entry_id) ";
             $where .= " AND CAST(`t$field_id`.`value` AS FLOAT) BETWEEN {$match[1]} AND {$match[2]} ";
@@ -380,7 +392,7 @@ class FieldNumber extends Field
         }
 
         // Equal to or less/greater than X
-        else if ( preg_match('/^(equal to or )?(less|greater) than\s*(-?(?:\d+(?:\.\d+)?|\.\d+))$/i', $data[0], $match) ) {
+        elseif (preg_match('/^(equal to or )?(less|greater) than\s*(-?(?:\d+(?:\.\d+)?|\.\d+))$/i', $data[0], $match)) {
 
             switch($match[2]) {
                 case 'less':
@@ -392,7 +404,7 @@ class FieldNumber extends Field
                     break;
             }
 
-            if ( $match[1] ) {
+            if ($match[1]) {
                 $expression .= '=';
             }
 
@@ -404,7 +416,7 @@ class FieldNumber extends Field
         }
 
         // Look for <=/< or >=/> symbols
-        else if ( preg_match('/^(=?[<>]=?)\s*(-?(?:\d+(?:\.\d+)?|\.\d+))$/i', $data[0], $match) ) {
+        elseif (preg_match('/^(=?[<>]=?)\s*(-?(?:\d+(?:\.\d+)?|\.\d+))$/i', $data[0], $match)) {
 
             $joins .= " LEFT JOIN `tbl_entries_data_$field_id` AS `t$field_id` ON (`e`.`id` = `t$field_id`.entry_id) ";
             $where .= sprintf(
@@ -427,16 +439,16 @@ class FieldNumber extends Field
 
     public function groupRecords($records)
     {
-        if ( !is_array($records) || empty($records) ) return;
+        if (!is_array($records) || empty($records)) return;
 
         $groups = array($this->get('element_name') => array());
 
-        foreach ( $records as $r ) {
+        foreach ($records as $r) {
             $data = $r->getData($this->get('id'));
 
             $value = $data['value'];
 
-            if ( !isset($groups[$this->get('element_name')][$value]) ) {
+            if (!isset($groups[$this->get('element_name')][$value])) {
                 $groups[$this->get('element_name')][$value] = array(
                     'attr' => array('value' => $value),
                     'records' => array(),

--- a/symphony/lib/toolkit/fields/field.author.php
+++ b/symphony/lib/toolkit/fields/field.author.php
@@ -37,7 +37,7 @@ class FieldAuthor extends Field implements ExportableField
         $authors = AuthorManager::fetch();
 
         $states = array();
-        foreach ( $authors as $a ) {
+        foreach ($authors as $a) {
             $states[$a->get('id')] = $a->getFullName();
         }
 
@@ -100,7 +100,7 @@ class FieldAuthor extends Field implements ExportableField
 
     public function set($field, $value)
     {
-        if ( $field === 'author_types' && !is_array($value) ) {
+        if ($field === 'author_types' && !is_array($value)) {
             $value = explode(',', $value);
         }
 
@@ -127,11 +127,11 @@ class FieldAuthor extends Field implements ExportableField
 
     public function findDefaults(array &$settings)
     {
-        if ( !isset($settings['allow_multiple_selection']) ) {
+        if (!isset($settings['allow_multiple_selection'])) {
             $settings['allow_multiple_selection'] = 'no';
         }
 
-        if ( !isset($settings['author_types']) ) {
+        if (!isset($settings['author_types'])) {
             $settings['author_types'] = array('developer', 'manager', 'author');
         }
     }
@@ -154,7 +154,7 @@ class FieldAuthor extends Field implements ExportableField
                 ))
         );
 
-        if ( isset($errors['author_types']) ) {
+        if (isset($errors['author_types'])) {
             $wrapper->appendChild(Widget::Error($label, $errors['author_types']));
         } else {
             $wrapper->appendChild($label);
@@ -180,7 +180,7 @@ class FieldAuthor extends Field implements ExportableField
 
         $types = $this->get('author_types');
 
-        if ( empty($types) ) {
+        if (empty($types)) {
             $errors['author_types'] = __('This is a required field.');
         }
 
@@ -189,13 +189,13 @@ class FieldAuthor extends Field implements ExportableField
 
     public function commit()
     {
-        if ( !parent::commit() ) {
+        if (!parent::commit()) {
             return false;
         }
 
         $id = $this->get('id');
 
-        if ( $id === false ) {
+        if ($id === false) {
             return false;
         }
 
@@ -204,7 +204,7 @@ class FieldAuthor extends Field implements ExportableField
         $fields['allow_multiple_selection'] = ($this->get('allow_multiple_selection') ? $this->get('allow_multiple_selection') : 'no');
         $fields['default_to_current_user'] = ($this->get('default_to_current_user') ? $this->get('default_to_current_user') : 'no');
 
-        if ( $this->get('author_types') != '' ) {
+        if ($this->get('author_types') != '') {
             $fields['author_types'] = implode(',', $this->get('author_types'));
         }
 
@@ -219,24 +219,24 @@ class FieldAuthor extends Field implements ExportableField
     {
         $value = isset($data['author_id']) ? $data['author_id'] : null;
 
-        if ( $this->get('default_to_current_user') === 'yes' && empty($data) && empty($_POST) ) {
+        if ($this->get('default_to_current_user') === 'yes' && empty($data) && empty($_POST)) {
             $value = array(Symphony::Author()->get('id'));
         }
 
-        if ( !is_array($value) ) {
+        if (!is_array($value)) {
             $value = array($value);
         }
 
         $options = array();
 
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
             #$options[] = array(null, false, null);
         }
 
         // Custom where to only show Authors based off the Author Types setting
         $types = $this->get('author_types');
 
-        if ( !empty($types) ) {
+        if (!empty($types)) {
             $types = implode('","', $this->get('author_types'));
             $where = 'user_type IN ("' . $types . '")';
         }
@@ -244,8 +244,8 @@ class FieldAuthor extends Field implements ExportableField
         $authors = AuthorManager::fetch('id', 'ASC', null, null, $where);
         $found = false;
 
-        foreach ( $authors as $a ) {
-            if ( in_array($a->get('id'), $value) ) {
+        foreach ($authors as $a) {
+            if (in_array($a->get('id'), $value)) {
                 $found = true;
             }
 
@@ -254,10 +254,10 @@ class FieldAuthor extends Field implements ExportableField
 
         // Ensure the selected Author is included in the options (incase
         // the settings change after the original entry was created)
-        if ( !$found && !is_null($value) ) {
+        if (!$found && !is_null($value)) {
             $authors = AuthorManager::fetchByID($value);
 
-            foreach ( $authors as $a ) {
+            foreach ($authors as $a) {
                 if (!isset($a)) continue;
                 $options[] = array($a->get('id'), in_array($a->get('id'), $value), $a->getFullName());
             }
@@ -265,24 +265,24 @@ class FieldAuthor extends Field implements ExportableField
 
         $fieldname = 'fields'.$fieldnamePrefix.'['.$this->get('element_name').']'.$fieldnamePostfix;
 
-        if ( $this->get('allow_multiple_selection') === 'yes' ) {
+        if ($this->get('allow_multiple_selection') === 'yes') {
             $fieldname .= '[]';
         }
 
         $label = Widget::Label($this->get('label'));
 
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
             $label->appendChild(new XMLElement('i', __('Optional')));
         }
 
         // Create the select
         $select = new XMLElement('select', null, ['name' => $fieldname]);
 
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $select->setAttribute('required', 'required');
         }
 
-        if ( $this->get('allow_multiple_selection') === 'yes' ) {
+        if ($this->get('allow_multiple_selection') === 'yes') {
             $size = count($options) + 1;
             if ($size > 10) {
                 $size = 10;
@@ -297,16 +297,16 @@ class FieldAuthor extends Field implements ExportableField
         if ($this->get('required') === 'yes') {
             $dummy->setAttribute('disabled', 'disabled');
         }
-        if ( $value[0] === null ) {
+        if ($value[0] === null) {
             $dummy->setAttribute('selected', 'selected');
         }
         $select->appendChild($dummy);
 
         // After the dummy all other options
-        foreach ( $options as $opt ) {
+        foreach ($options as $opt) {
             $option = new XMLElement('option', $opt[2]); // Author name
             $option->setAttribute('value', $opt[0]); // Value
-            if ( $opt[1] === true ) {
+            if ($opt[1] === true) {
                 $option->setAttribute('selected', 'selected');
             }
             $select->appendChild($option);
@@ -315,7 +315,7 @@ class FieldAuthor extends Field implements ExportableField
         #$select = Widget::Select($fieldname, $options, ($this->get('allow_multiple_selection') === 'yes' ? array('multiple' => 'multiple') : null));
         $label->appendChild($select);
 
-        if ( $flagWithError != null ) {
+        if ($flagWithError != null) {
             $wrapper->appendChild(Widget::Error($label, $flagWithError));
         } else {
             $wrapper->appendChild($label);
@@ -326,17 +326,17 @@ class FieldAuthor extends Field implements ExportableField
     {
         $status = self::__OK__;
 
-        if ( !is_array($data) && !empty($data) ) {
+        if (!is_array($data) && !empty($data)) {
             return array('author_id' => $data);
         }
 
-        if ( empty($data) ) {
+        if (empty($data)) {
             return null;
         }
 
         $result = array();
 
-        foreach ( $data as $id ) {
+        foreach ($data as $id) {
             $result['author_id'][] = $id;
         }
 
@@ -351,15 +351,15 @@ class FieldAuthor extends Field implements ExportableField
     {
         $data['author_id'] = $data['author_id'] ?? null;
 
-        if ( !is_array($data['author_id']) ) {
+        if (!is_array($data['author_id'])) {
             $data['author_id'] = array($data['author_id']);
         }
 
         $list = new XMLElement($this->get('element_name'));
         $authors = AuthorManager::fetchByID($data['author_id']);
 
-        foreach ( $authors as $author ) {
-            if ( is_null($author) ) {
+        foreach ($authors as $author) {
+            if (is_null($author)) {
                 continue;
             }
 
@@ -428,14 +428,14 @@ class FieldAuthor extends Field implements ExportableField
         $modes = (object)$this->getExportModes();
 
         // Make sure we have an array to work with:
-        if ( isset($data['author_id']) && is_array($data['author_id']) === false ) {
+        if (isset($data['author_id']) && is_array($data['author_id']) === false) {
             $data['author_id'] = array(
                 $data['author_id']
             );
         }
 
         // Return the author IDs:
-        if ( $mode === $modes->listAuthor || $mode === $modes->getPostdata ) {
+        if ($mode === $modes->listAuthor || $mode === $modes->getPostdata) {
             return isset($data['author_id'])
                 ? $data['author_id']
                 : array();
@@ -447,16 +447,16 @@ class FieldAuthor extends Field implements ExportableField
             : array();
         $items = array();
 
-        foreach ( $authors as $author ) {
-            if ( is_null($author) ) {
+        foreach ($authors as $author) {
+            if (is_null($author)) {
                 continue;
             }
 
-            if ( $mode === $modes->listAuthorObject ) {
+            if ($mode === $modes->listAuthorObject) {
                 $items[] = $author;
-            } elseif ( $mode === $modes->listValue ) {
+            } elseif ($mode === $modes->listValue) {
                 $items[] = $author->getFullName();
-            } elseif ( $mode === $modes->listAuthorToValue ) {
+            } elseif ($mode === $modes->listAuthorToValue) {
                 $items[$data['author_id']] = $author->getFullName();
             }
         }
@@ -472,10 +472,10 @@ class FieldAuthor extends Field implements ExportableField
     {
         $field_id = $this->get('id');
 
-        if ( self::isFilterRegex($data[0]) ) {
+        if (self::isFilterRegex($data[0])) {
             $this->_key++;
 
-            if ( preg_match('/^regexp:/i', $data[0]) ) {
+            if (preg_match('/^regexp:/i', $data[0])) {
                 $pattern = preg_replace('/^regexp:\s*/i', null, $this->cleanValue($data[0]));
                 $regex = 'REGEXP';
             } else {
@@ -483,7 +483,7 @@ class FieldAuthor extends Field implements ExportableField
                 $regex = 'NOT REGEXP';
             }
 
-            if ( strlen($pattern) == 0 ) {
+            if (strlen($pattern) == 0) {
                 return;
             }
 
@@ -505,14 +505,14 @@ class FieldAuthor extends Field implements ExportableField
                     ) {$regex} '{$pattern}'
                 )
             ";
-        } elseif ( self::isFilterSQL($data[0]) ) {
+        } elseif (self::isFilterSQL($data[0])) {
             $this->buildFilterSQL($data[0], array('username', 'first_name', 'last_name'), $joins, $where);
-        } elseif ( $andOperation ) {
-            foreach ( $data as $value ) {
+        } elseif ($andOperation) {
+            foreach ($data as $value) {
                 $this->_key++;
                 $value = $this->cleanValue($value);
 
-                if ( self::__parseFilter($value) == "author_id" ) {
+                if (self::__parseFilter($value) == "author_id") {
                     $where .= "
                         AND t{$field_id}_{$this->_key}.author_id = '{$value}'
                     ";
@@ -542,11 +542,11 @@ class FieldAuthor extends Field implements ExportableField
                 }
             }
         } else {
-            if ( !is_array($data) ) {
+            if (!is_array($data)) {
                 $data = array($data);
             }
 
-            foreach ( $data as &$value ) {
+            foreach ($data as &$value) {
                 $value = $this->cleanValue($value);
             }
 
@@ -582,7 +582,7 @@ class FieldAuthor extends Field implements ExportableField
 
     public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC')
     {
-        if ( $this->isRandomOrder($order) ) {
+        if ($this->isRandomOrder($order)) {
             $sort = 'ORDER BY RAND()';
         } else {
             $joins .= "
@@ -595,7 +595,7 @@ class FieldAuthor extends Field implements ExportableField
 
     public function buildSortingSelectSQL($sort, $order = 'ASC')
     {
-        if ( $this->isRandomOrder($order) ) {
+        if ($this->isRandomOrder($order)) {
             return null;
         }
         return '`a`.`first_name`, `a`.`last_name`';
@@ -607,38 +607,42 @@ class FieldAuthor extends Field implements ExportableField
 
     public function getExampleFormMarkup()
     {
+        $fieldId = $this->get('id');
+        $fieldName = $this->get('element_name');
+        $attrName = 'fields[' . $fieldName . ']';
         $authors = AuthorManager::fetch();
         $options = array();
 
-        foreach ( $authors as $a ) {
+        $div = new XMLElement('div', null, array('class' => 'form-field'));
+        foreach ($authors as $a) {
             $options[] = array($a->get('id'), null, $a->getFullName());
         }
 
-        $fieldname = 'fields['.$this->get('element_name').']';
-
-        if ( $this->get('allow_multiple_selection') === 'yes' ) {
-            $fieldname .= '[]';
+        if ($this->get('allow_multiple_selection') === 'yes') {
+            $attrName .= '[]';
         }
 
-        $labelText = $this->get('label') . "\n<!-- Please note: The values are a static example. To obtain the values dynamically, use a data source and access it in your template. -->";
+        $labelText = $this->get('label') . __("\n<!-- Please note: The values are a static example. To obtain the values dynamically, use a data source and access it in your template. -->");
         $label = new XMLElement('label');
         $label->setValue($labelText . ' ');
+        $label->setAttribute('for', $fieldName . '-' . $fieldId);
 
         if ($this->get('required') === 'yes') {
             $mark = new XMLElement('span', '*');
-            $mark->setAttribute('aria-label', 'Required field');
+            $mark->setAttribute('aria-hidden', 'true');
             $mark->setAttribute('class', 'required-mark');
             $label->appendChild($mark);
         }
 
         // Create the select
-        $select = new XMLElement('select', null, ['name' => $fieldname]);
+        $select = new XMLElement('select', null, array('name' => $attrName));
+        $select->setAttribute('id', $fieldName . '-' . $fieldId);
 
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $select->setAttribute('required', 'required');
         }
 
-        if ( $this->get('allow_multiple_selection') === 'yes' ) {
+        if ($this->get('allow_multiple_selection') === 'yes') {
             $size = count($options) + 1;
             if ($size > 10) {
                 $size = 10;
@@ -661,16 +665,16 @@ class FieldAuthor extends Field implements ExportableField
         foreach ($options as $opt) {
             $option = new XMLElement('option', $opt[2]); // Display text
             $option->setAttribute('value', $opt[0]);     // Value
-            if ( $opt[1] === true ) {
+            if ($opt[1] === true) {
                 $option->setAttribute('selected', 'selected');
             }
             $select->appendChild($option);
         }
 
-        #$select = Widget::Select($fieldname, $options, $attr);
-        $label->appendChild($select);
+        $div->appendChild($label);
+        $div->appendChild($select);
 
-        return $label;
+        return $div;
     }
 
     /*-------------------------------------------------------------------------
@@ -679,20 +683,20 @@ class FieldAuthor extends Field implements ExportableField
 
     public function groupRecords($records)
     {
-        if ( !is_array($records) || empty($records) ) {
+        if (!is_array($records) || empty($records)) {
             return;
         }
 
         $groups = array($this->get('element_name') => array());
 
-        foreach ( $records as $r ) {
+        foreach ($records as $r) {
             $data = $r->getData($this->get('id'));
             $author_id = !isset($data['author_id']) ? 0 : $data['author_id'];
 
-            if ( !isset($groups[$this->get('element_name')][$author_id]) ) {
+            if (!isset($groups[$this->get('element_name')][$author_id])) {
                 $author = AuthorManager::fetchByID($author_id);
                 // If there is an author, use those values, otherwise just blank it.
-                if ( $author instanceof Author ) {
+                if ($author instanceof Author) {
                     $username = $author->get('username');
                     $full_name = $author->getFullName();
                 } else {

--- a/symphony/lib/toolkit/fields/field.checkbox.php
+++ b/symphony/lib/toolkit/fields/field.checkbox.php
@@ -102,7 +102,7 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
 
     public function findDefaults(array &$settings)
     {
-        if ( !isset($settings['default_state']) ) {
+        if (!isset($settings['default_state'])) {
             $settings['default_state'] = 'off';
         }
     }
@@ -116,7 +116,7 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
         $label->setAttribute('class', 'column');
         $input = Widget::Input('fields['.$this->get('sortorder').'][default_state]', 'on', 'checkbox');
 
-        if ( $this->get('default_state') == 'on' ) {
+        if ($this->get('default_state') == 'on') {
             $input->setAttribute('checked', 'checked');
         }
 
@@ -129,13 +129,13 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
 
     public function commit()
     {
-        if ( !parent::commit() ) {
+        if (!parent::commit()) {
             return false;
         }
 
         $id = $this->get('id');
 
-        if ( $id === false ) {
+        if ($id === false) {
             return false;
         }
 
@@ -152,11 +152,11 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
 
     public function displayPublishPanel(XMLElement &$wrapper, $data = null, $flagWithError = null, $fieldnamePrefix = null, $fieldnamePostfix = null, $entry_id = null)
     {
-        if ( !$data ) {
+        if (!$data) {
             // TODO: Don't rely on $_POST
-            if ( isset($_POST) && !empty($_POST) ) {
+            if (isset($_POST) && !empty($_POST)) {
                 $value = 'no';
-            } elseif ( $this->get('default_state') == 'on' ) {
+            } elseif ($this->get('default_state') == 'on') {
                 $value = 'yes';
             } else {
                 $value = 'no';
@@ -167,18 +167,18 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
 
         $label = Widget::Label();
 
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
             $label->appendChild(new XMLElement('i', __('Optional')));
         }
 
         $input = Widget::Input('fields'.$fieldnamePrefix.'['.$this->get('element_name').']'.$fieldnamePostfix, 'yes', 'checkbox', ($value === 'yes' ? array('checked' => 'checked') : null));
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
 
         $label->setValue($input->generate(false) . ' ' . $this->get('label'));
 
-        if ( $flagWithError != null ) {
+        if ($flagWithError != null) {
             $wrapper->appendChild(Widget::Error($label, $flagWithError));
         } else {
             $wrapper->appendChild($label);
@@ -195,7 +195,7 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
         // then the field has 'no value' in the context of being required. RE: #1569
         $has_no_value = ($has_no_value === false) ? !in_array(strtolower($data), array('on', 'yes')) : true;
 
-        if ( $this->get('required') === 'yes' && $has_no_value ) {
+        if ($this->get('required') === 'yes' && $has_no_value) {
             $message = __('‘%s’ is a required field.', array($this->get('label')));
 
             return self::__MISSING_FIELDS__;
@@ -252,9 +252,9 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
         $modes = (object)$this->getImportModes();
         $value = $this->processRawFieldData($data, $status, $message, true, $entry_id);
 
-        if ( $mode === $modes->getValue ) {
+        if ($mode === $modes->getValue) {
             return $value['value'];
-        } elseif ( $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->getPostdata) {
             return $value;
         }
 
@@ -293,7 +293,7 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
         $modes = (object)$this->getExportModes();
 
         // Export unformatted:
-        if ( $mode === $modes->getPostdata ) {
+        if ($mode === $modes->getPostdata) {
             return (
                 isset($data['value'])
                 && $data['value'] === 'yes'
@@ -302,7 +302,7 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
             );
 
             // Export formatted:
-        } elseif ( $mode === $modes->getValue ) {
+        } elseif ($mode === $modes->getValue) {
             return (
                 isset($data['value'])
                 && $data['value'] === 'yes'
@@ -311,7 +311,7 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
             );
 
             // Export boolean:
-        } elseif ( $mode === $modes->getBoolean ) {
+        } elseif ($mode === $modes->getBoolean) {
             return (
                 isset($data['value'])
                 && $data['value'] === 'yes'
@@ -329,12 +329,12 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
     {
         $existing_options = array('yes', 'no');
 
-        if ( is_array($existing_options) && !empty($existing_options) ) {
+        if (is_array($existing_options) && !empty($existing_options)) {
             $optionlist = new XMLElement('ul');
             $optionlist->setAttribute('class', 'tags');
             $optionlist->setAttribute('data-interactive', 'data-interactive');
 
-            foreach ( $existing_options as $option ) {
+            foreach ($existing_options as $option) {
                 $optionlist->appendChild(new XMLElement('li', $option));
             }
 
@@ -347,8 +347,8 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
         $field_id = $this->get('id');
         $default_state = ($this->get('default_state') == "on") ? 'yes' : 'no';
 
-        if ( $andOperation ) {
-            foreach ( $data as $value ) {
+        if ($andOperation) {
+            foreach ($data as $value) {
                 $this->_key++;
                 $value = $this->cleanValue($value);
                 $joins .= "
@@ -357,7 +357,7 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
                         ON (e.id = t{$field_id}_{$this->_key}.entry_id)
                 ";
 
-                if ( $default_state == $value ) {
+                if ($default_state == $value) {
                     $where .= "
                         AND (
                             t{$field_id}_{$this->_key}.value = '{$value}'
@@ -372,11 +372,11 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
                 }
             }
         } else {
-            if ( !is_array($data) ) {
+            if (!is_array($data)) {
                 $data = array($data);
             }
 
-            foreach ( $data as &$value ) {
+            foreach ($data as &$value) {
                 $value = $this->cleanValue($value);
             }
 
@@ -388,7 +388,7 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
                     ON (e.id = t{$field_id}_{$this->_key}.entry_id)
             ";
 
-            if ( strpos($data, $default_state) !== false ) {
+            if (strpos($data, $default_state) !== false) {
                 $where .= "
                     AND (
                         t{$field_id}_{$this->_key}.value IN ('{$data}')
@@ -412,7 +412,7 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
 
     public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC')
     {
-        if ( $this->isRandomOrder($order) ) {
+        if ($this->isRandomOrder($order)) {
             $sort = 'ORDER BY RAND()';
         } else {
             $sort = sprintf(
@@ -440,18 +440,18 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
 
     public function groupRecords($records)
     {
-        if ( !is_array($records) || empty($records) ) {
+        if (!is_array($records) || empty($records)) {
             return;
         }
 
         $groups = array($this->get('element_name') => array());
 
-        foreach ( $records as $r ) {
+        foreach ($records as $r) {
             $data = $r->getData($this->get('id'));
 
             $value = $data['value'];
 
-            if ( !isset($groups[$this->get('element_name')][$value]) ) {
+            if (!isset($groups[$this->get('element_name')][$value])) {
                 $groups[$this->get('element_name')][$value] = array(
                     'attr' => array('value' => $value),
                     'records' => array(),
@@ -471,23 +471,25 @@ class FieldCheckbox extends Field implements ExportableField, ImportableField
 
     public function getExampleFormMarkup()
     {
+        $div = new XMLElement('div', null, array('class' => 'form-field'));
         $label = new XMLElement('label');
-
         $input = Widget::Input('fields['.$this->get('element_name').']', 'yes', 'checkbox', ($this->get('default_state') == 'on' ? array('checked' => 'checked') : null));
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
         $label->appendChild($input);
 
         $labelText = new XMLElement('span', $this->get('label'));
+        $label->appendChild($labelText);
         if ($this->get('required') === 'yes') {
             $mark = new XMLElement('span', '*');
-            $mark->setAttribute('aria-label', 'Required field');
+            $mark->setAttribute('aria-hidden', 'true');
             $mark->setAttribute('class', 'required-mark');
-            $labelText->appendChild($mark);
+            $label->appendChild($mark);
         }
-        $label->appendChild($labelText);
 
-        return $label;
+        $div->appendChild($label);
+
+        return $div;
     }
 }

--- a/symphony/lib/toolkit/fields/field.color.php
+++ b/symphony/lib/toolkit/fields/field.color.php
@@ -96,7 +96,7 @@ class FieldColor extends Field implements ExportableField, ImportableField
 
     public function commit()
     {
-        if ( !parent::commit() ) return false;
+        if (!parent::commit()) return false;
 
         return FieldManager::saveSettings($this->get('id'), [
             'default' => $this->get('default'),
@@ -114,17 +114,16 @@ class FieldColor extends Field implements ExportableField, ImportableField
         $input = Widget::input("fields{$fieldnamePrefix}[{$this->get('element_name')}]{$fieldnamePostfix}", $value, 'color', [
             'value' => $value ?? $this->get('default')
         ]);
-        if ( $this->get('required') === 'yes' ) {
-            $input->setAttribute('required', 'required');
-        }
+        // `color` inputs always have a value (default #000000) and cannot be empty.
+        // The `required` attribute is therefore not applicable.
 
         $label = Widget::label($this->get('label'));
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
             $label->appendChild(new XMLElement('i', __('Optional')));
         }
         $label->appendChild($input);
 
-        if ( $flagWithError != null ) {
+        if ($flagWithError != null) {
             $wrapper->appendChild(Widget::Error($label, $flagWithError));
         } else {
             $wrapper->appendChild($label);
@@ -140,12 +139,12 @@ class FieldColor extends Field implements ExportableField, ImportableField
         );
         $message = null;
 
-        if ( $this->get('required') === 'yes' && strlen($data) === 0 ) {
+        if ($this->get('required') === 'yes' && strlen($data) === 0) {
             $message = $messages['required'];
             return self::__MISSING_FIELDS__;
         }
 
-        if ( strlen($data) > 0 && !preg_match('/^#[0-9a-fA-F]{6}$/', $data) ) {
+        if (strlen($data) > 0 && !preg_match('/^#[0-9a-fA-F]{6}$/', $data)) {
             $message = $messages['invalid'];
             return self::__INVALID_FIELDS__;
         }
@@ -164,7 +163,7 @@ class FieldColor extends Field implements ExportableField, ImportableField
         $element = new XMLElement($this->get('element_name'), $value);
 
         // Return additional attribute 'default'
-        if ( $this->get('default') !== null ) {
+        if ($this->get('default') !== null) {
             $element->setAttribute('default', $this->get('default'));
         }
 
@@ -183,10 +182,15 @@ class FieldColor extends Field implements ExportableField, ImportableField
 
     public function getExampleFormMarkup()
     {
-        $label = new XMLElement('label', $this->get('label'));
+        $fieldId = $this->get('id');
+        $fieldName = $this->get('element_name');
+
+        $div = new XMLElement('div', null, array('class' => 'form-field'));
+        $label = Widget::Label($this->get('label'));
+        $label->setAttribute('for', $fieldName . '-' . $fieldId);
         if ($this->get('required') === 'yes') {
             $mark = new XMLElement('span', '*');
-            $mark->setAttribute('aria-label', 'Required field');
+            $mark->setAttribute('aria-hidden', 'true');
             $mark->setAttribute('class', 'required-mark');
             $label->appendChild($mark);
         }
@@ -194,13 +198,14 @@ class FieldColor extends Field implements ExportableField, ImportableField
         $input = Widget::input('fields['.$this->get('element_name').']', null, 'color', [
             'value' => $this->get('default')
         ]);
-        if ( $this->get('required') === 'yes' ) {
-            $input->setAttribute('required', 'required');
-        }
+        $input->setAttribute('id', $fieldName . '-' . $fieldId);
+        // `color` inputs always have a value (default #000000) and cannot be empty.
+        // The `required` attribute is therefore not applicable.
 
-        $label->appendChild($input);
+        $div->appendChild($label);
+        $div->appendChild($input);
 
-        return $label;
+        return $div;
     }
 
     /*-------------------------------------------------------------------------
@@ -220,9 +225,9 @@ class FieldColor extends Field implements ExportableField, ImportableField
         $message = $status = null;
         $modes = (object)$this->getImportModes();
 
-        if ( $mode === $modes->getValue ) {
+        if ($mode === $modes->getValue) {
             return $data;
-        } else if ( $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->getPostdata) {
             return $this->processRawFieldData($data, $status, $message, true, $entry_id);
         }
 
@@ -261,7 +266,7 @@ class FieldColor extends Field implements ExportableField, ImportableField
         $modes = (object)$this->getExportModes();
 
         // Export unformatted:
-        if ( $mode === $modes->getUnformatted || $mode === $modes->getPostdata ) {
+        if ($mode === $modes->getUnformatted || $mode === $modes->getPostdata) {
             return isset($data['value'])
                 ? $data['value']
                 : null;
@@ -276,16 +281,16 @@ class FieldColor extends Field implements ExportableField, ImportableField
 
     public function groupRecords($records)
     {
-        if ( !is_array($records) || empty($records) ) return;
+        if (!is_array($records) || empty($records)) return;
 
         $groups = array($this->get('element_name') => array());
 
-        foreach ( $records as $r ) {
+        foreach ($records as $r) {
             $data = $r->getData($this->get('id'));
 
             $value = $data['value'];
 
-            if ( !isset($groups[$this->get('element_name')][$value]) ) {
+            if (!isset($groups[$this->get('element_name')][$value])) {
                 $groups[$this->get('element_name')][$value] = array(
                     'attr' => array('value' => $value),
                     'records' => array(),

--- a/symphony/lib/toolkit/fields/field.date.php
+++ b/symphony/lib/toolkit/fields/field.date.php
@@ -176,9 +176,9 @@ class FieldDate extends Field implements ExportableField, ImportableField
             $parts = self::isEqualTo($parts, $direction, $equal_to);
 
             // Year/Month/Day/Time
-        } elseif ( preg_match('/^\d{1,4}[-\/]\d{1,2}[-\/]\d{1,2}\s\d{1,2}:\d{2}/', $string, $matches) ) {
+        } elseif (preg_match('/^\d{1,4}[-\/]\d{1,2}[-\/]\d{1,2}\s\d{1,2}:\d{2}/', $string, $matches)) {
             // Handles the case of `to` filters
-            if ( $equal_to || is_null($direction) ) {
+            if ($equal_to || is_null($direction)) {
                 $parts['start'] = $parts['end'] = DateTimeObj::get('Y-m-d H:i:s', $string);
             } else {
                 $parts['start'] = DateTimeObj::get('Y-m-d H:i:s', $string . ' - 1 second');
@@ -186,7 +186,7 @@ class FieldDate extends Field implements ExportableField, ImportableField
             }
 
             // Year/Month/Day
-        } elseif ( preg_match('/^\d{1,4}[-\/]\d{1,2}[-\/]\d{1,2}$/', $string, $matches) ) {
+        } elseif (preg_match('/^\d{1,4}[-\/]\d{1,2}[-\/]\d{1,2}$/', $string, $matches)) {
             $year_month_day = current($matches);
 
             $parts['start'] = "$year_month_day 00:00:00";
@@ -195,7 +195,7 @@ class FieldDate extends Field implements ExportableField, ImportableField
             $parts = self::isEqualTo($parts, $direction, $equal_to);
 
             // Year/Month
-        } elseif ( preg_match('/^\d{1,4}[-\/]\d{1,2}$/', $string, $matches) ) {
+        } elseif (preg_match('/^\d{1,4}[-\/]\d{1,2}$/', $string, $matches)) {
             $year_month = current($matches);
 
             $parts['start'] = "$year_month-01 00:00:00";
@@ -207,7 +207,7 @@ class FieldDate extends Field implements ExportableField, ImportableField
         } else {
             // Handles the case of `to` filters
 
-            if ( $equal_to || is_null($direction) ) {
+            if ($equal_to || is_null($direction)) {
                 $parts['start'] = $parts['end'] = DateTimeObj::get('Y-m-d H:i:s', $string);
             } else {
                 $parts['start'] = DateTimeObj::get('Y-m-d H:i:s', $string . ' - 1 second');
@@ -235,11 +235,11 @@ class FieldDate extends Field implements ExportableField, ImportableField
      */
     public static function isEqualTo(array $parts, $direction, $equal_to = false)
     {
-        if ( !$equal_to ) {
+        if (!$equal_to) {
             return $parts;
         }
 
-        if ( $direction == 'later' ) {
+        if ($direction == 'later') {
             $parts['end'] = $parts['start'];
         } else {
             $parts['start'] = $parts['end'];
@@ -253,11 +253,11 @@ class FieldDate extends Field implements ExportableField, ImportableField
         $string = self::cleanFilterString($string);
 
         // Relative check, earlier or later
-        if ( preg_match('/^(equal to or )?(earlier|later) than (.*)$/i', $string, $match) ) {
+        if (preg_match('/^(equal to or )?(earlier|later) than (.*)$/i', $string, $match)) {
             $string = $match[3];
 
             // Validate date
-            if ( !DateTimeObj::validate($string) ) {
+            if (!DateTimeObj::validate($string)) {
                 return self::ERROR;
             }
 
@@ -289,7 +289,7 @@ class FieldDate extends Field implements ExportableField, ImportableField
             || !preg_match('/\s+to\s+/i', $string)
         ) {
             // Validate
-            if ( !DateTimeObj::validate($string) ) {
+            if (!DateTimeObj::validate($string)) {
                 return self::ERROR;
             }
 
@@ -297,14 +297,14 @@ class FieldDate extends Field implements ExportableField, ImportableField
             $string = $parts['start'] . ' to ' . $parts['end'];
 
             // Match date ranges
-        } elseif ( preg_match('/\s+to\s+/i', $string) ) {
-            if ( !$parts = preg_split('/\s+to\s+/', $string, 2, PREG_SPLIT_NO_EMPTY) ) {
+        } elseif (preg_match('/\s+to\s+/i', $string)) {
+            if (!$parts = preg_split('/\s+to\s+/', $string, 2, PREG_SPLIT_NO_EMPTY)) {
                 return self::ERROR;
             }
 
-            foreach ( $parts as $i => &$part ) {
+            foreach ($parts as $i => &$part) {
                 // Validate
-                if ( !DateTimeObj::validate($part) ) {
+                if (!DateTimeObj::validate($part)) {
                     return self::ERROR;
                 }
 
@@ -315,7 +315,7 @@ class FieldDate extends Field implements ExportableField, ImportableField
         }
 
         // Parse the full date range and return an array
-        if ( !$parts = preg_split('/\s+to\s+/i', $string, 2, PREG_SPLIT_NO_EMPTY) ) {
+        if (!$parts = preg_split('/\s+to\s+/i', $string, 2, PREG_SPLIT_NO_EMPTY)) {
             return self::ERROR;
         }
 
@@ -324,7 +324,7 @@ class FieldDate extends Field implements ExportableField, ImportableField
         list($start, $end) = $parts;
 
         // Validate
-        if ( !DateTimeObj::validate($start) || !DateTimeObj::validate($end) ) {
+        if (!DateTimeObj::validate($start) || !DateTimeObj::validate($end)) {
             return self::ERROR;
         }
 
@@ -344,12 +344,12 @@ class FieldDate extends Field implements ExportableField, ImportableField
     {
         $field_id = $this->get('id');
 
-        if ( empty($data) ) {
+        if (empty($data)) {
             return;
         }
 
-        if ( $andOperation ) {
-            foreach ( $data as $date ) {
+        if ($andOperation) {
+            foreach ($data as $date) {
                 // Prevent the DateTimeObj creating a range that isn't supported by MySQL.
                 $start = ($date['start'] === self::$min_date) ? self::$min_date : DateTimeObj::getGMT('Y-m-d H:i:s', $date['start']);
                 $end = ($date['end'] === self::$max_date) ? self::$max_date : DateTimeObj::getGMT('Y-m-d H:i:s', $date['end']);
@@ -362,7 +362,7 @@ class FieldDate extends Field implements ExportableField, ImportableField
         } else {
             $tmp = array();
 
-            foreach ( $data as $date ) {
+            foreach ($data as $date) {
                 // Prevent the DateTimeObj creating a range that isn't supported by MySQL.
                 $start = ($date['start'] === self::$min_date) ? self::$min_date : DateTimeObj::getGMT('Y-m-d H:i:s', $date['start']);
                 $end = ($date['end'] === self::$max_date) ? self::$max_date : DateTimeObj::getGMT('Y-m-d H:i:s', $date['end']);
@@ -401,7 +401,7 @@ class FieldDate extends Field implements ExportableField, ImportableField
 
     public function findDefaults(array &$settings)
     {
-        if ( !isset($settings['pre_populate']) ) {
+        if (!isset($settings['pre_populate'])) {
             $settings['pre_populate'] = $this->get('pre_populate');
         }
     }
@@ -431,13 +431,13 @@ class FieldDate extends Field implements ExportableField, ImportableField
 
     public function commit()
     {
-        if ( !parent::commit() ) {
+        if (!parent::commit()) {
             return false;
         }
 
         $id = $this->get('id');
 
-        if ( $id === false ) {
+        if ($id === false) {
             return false;
         }
 
@@ -461,26 +461,26 @@ class FieldDate extends Field implements ExportableField, ImportableField
         $time = $this->get('time');
 
         // New entry
-        if ( empty($data) && is_null($flagWithError) && !is_null($this->get('pre_populate')) ) {
+        if (empty($data) && is_null($flagWithError) && !is_null($this->get('pre_populate'))) {
             $prepopulate = $this->get('pre_populate');
 
             $date = self::parseDate($prepopulate);
             $date = $date['start'];
             #$value = $this->formatDate($date);
-            if ( $time === 'yes' ) {
+            if ($time === 'yes') {
                 $value = DateTimeObj::format($date, 'Y-m-d\TH:i');
             } else {
                 $value = DateTimeObj::format($date, 'Y-m-d');
             }
 
             // Error entry, display original data
-        } elseif ( !is_null($flagWithError) ) {
+        } elseif (!is_null($flagWithError)) {
             $value = $_POST['fields'][$name];
 
             // Empty entry
-        } elseif ( isset($data['value']) ) {
+        } elseif (isset($data['value'])) {
             #$value = $this->formatDate($data['value']);
-            if ( $time === 'yes' ) {
+            if ($time === 'yes') {
                 $value = DateTimeObj::format($data['value'], 'Y-m-d\TH:i');
             } else {
                 $value = DateTimeObj::format($data['value'], 'Y-m-d');
@@ -489,18 +489,18 @@ class FieldDate extends Field implements ExportableField, ImportableField
 
         $label = Widget::Label($this->get('label'));
 
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
             $label->appendChild(new XMLElement('i', __('Optional')));
         }
 
         $type = 'date';
-        if ( $time === 'yes' ) {
+        if ($time === 'yes') {
             $type = 'datetime-local';
         }
 
         // Input
         $input = Widget::Input("fields{$fieldnamePrefix}[{$name}]", $value, $type);
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
 
@@ -508,7 +508,7 @@ class FieldDate extends Field implements ExportableField, ImportableField
         $label->setAttribute('class', 'date');
 
         // Calendar
-        if ( $this->get('calendar') === 'yes' ) {
+        if ($this->get('calendar') === 'yes') {
             $wrapper->setAttribute('data-interactive', 'data-interactive');
 
             $ul = new XMLElement('ul');
@@ -524,7 +524,7 @@ class FieldDate extends Field implements ExportableField, ImportableField
         }
 
         // Wrap label in error
-        if ( !is_null($flagWithError) ) {
+        if (!is_null($flagWithError)) {
             $label = Widget::Error($label, $flagWithError);
         }
         $wrapper->appendChild($label);
@@ -535,15 +535,15 @@ class FieldDate extends Field implements ExportableField, ImportableField
         $message = null;
 
         // If this field is required
-        if ( $this->get('required') === 'yes' && strlen(trim($data)) == 0 ) {
+        if ($this->get('required') === 'yes' && strlen(trim($data)) == 0) {
             $message = __('‘%s’ is a required field.', array($this->get('label')));
             return self::__MISSING_FIELDS__;
-        } elseif ( empty($data) ) {
+        } elseif (empty($data)) {
             return self::__OK__;
         }
 
         // Handle invalid dates
-        if ( !DateTimeObj::validate($data) ) {
+        if (!DateTimeObj::validate($data)) {
             $message = __('The date specified in ‘%s’ is invalid.', array($this->get('label')));
             return self::__INVALID_FIELDS__;
         }
@@ -557,20 +557,20 @@ class FieldDate extends Field implements ExportableField, ImportableField
         $timestamp = null;
 
         // Prepopulate date
-        if ( is_null($data) || $data == '' ) {
-            if ( $this->get('pre_populate') !='' ) {
+        if (is_null($data) || $data == '') {
+            if ($this->get('pre_populate') !='') {
                 $date = self::parseDate($this->get('pre_populate'));
                 $date = $date['start'];
                 $timestamp = $this->formatDate($date);
             }
 
             // Convert given date to timestamp
-        } elseif ( $status == self::__OK__ && DateTimeObj::validate($data) ) {
+        } elseif ($status == self::__OK__ && DateTimeObj::validate($data)) {
             $timestamp = DateTimeObj::get('U', $data);
         }
 
         // Valid date
-        if ( !is_null($timestamp) ) {
+        if (!is_null($timestamp)) {
             return array(
                 'value' => DateTimeObj::get('c', $timestamp),
                 'date' => DateTimeObj::getGMT('Y-m-d H:i:s', $timestamp)
@@ -591,10 +591,10 @@ class FieldDate extends Field implements ExportableField, ImportableField
 
     public function appendFormattedElement(XMLElement &$wrapper, $data, $encode = false, $mode = null, $entry_id = null)
     {
-        if ( isset($data['value']) ) {
+        if (isset($data['value'])) {
 
             // Get date
-            if ( is_array($data['value']) ) {
+            if (is_array($data['value'])) {
                 $date = current($data['value']);
             } else {
                 $date = $data['value'];
@@ -608,7 +608,7 @@ class FieldDate extends Field implements ExportableField, ImportableField
     {
         $value = '';
 
-        if ( isset($data['value']) ) {
+        if (isset($data['value'])) {
             $value = $this->formatDate($data['value']);
         }
 
@@ -638,29 +638,29 @@ class FieldDate extends Field implements ExportableField, ImportableField
         $modes = (object)$this->getImportModes();
 
         // Prepopulate date:
-        if ( $data === null || $data === '' ) {
-            if ( !is_null($this->get('pre_populate')) ) {
+        if ($data === null || $data === '') {
+            if (!is_null($this->get('pre_populate'))) {
                 $timestamp = self::parseDate($this->get('pre_populate'));
                 $timestamp = $timestamp['start'];
             }
 
             // DateTime to timestamp:
-        } elseif ( $data instanceof DateTime ) {
+        } elseif ($data instanceof DateTime) {
             $timestamp = $data->getTimestamp();
 
             // Convert given date to timestamp:
-        } elseif ( DateTimeObj::validate($data) ) {
+        } elseif (DateTimeObj::validate($data)) {
             $timestamp = DateTimeObj::get('U', $data);
         }
 
         // Valid date found:
-        if ( isset($timestamp) ) {
+        if (isset($timestamp)) {
             $value = DateTimeObj::get('c', $timestamp);
         }
 
-        if ( $mode === $modes->getValue ) {
+        if ($mode === $modes->getValue) {
             return $value;
-        } elseif ( $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->getPostdata) {
             return $this->processRawFieldData($data, $status, $message, true, $entry_id);
         }
 
@@ -698,14 +698,14 @@ class FieldDate extends Field implements ExportableField, ImportableField
     {
         $modes = (object)$this->getExportModes();
 
-        if ( $mode === $modes->getValue ) {
+        if ($mode === $modes->getValue) {
             return $this->formatDate(
 
                 isset($data['value']) ? $data['value'] : null
             );
         }
 
-        if ( $mode === $modes->getObject ) {
+        if ($mode === $modes->getObject) {
             $timezone = Symphony::Configuration()->get('timezone', 'region');
 
             $date = new DateTime(
@@ -715,7 +715,7 @@ class FieldDate extends Field implements ExportableField, ImportableField
             $date->setTimezone(new DateTimeZone($timezone));
 
             return $date;
-        } elseif ( $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->getPostdata) {
             return isset($data['value'])
                 ? $data['value']
                 : null;
@@ -730,31 +730,31 @@ class FieldDate extends Field implements ExportableField, ImportableField
 
     public function buildDSRetrievalSQL($data, &$joins, &$where, $andOperation = false)
     {
-        if ( self::isFilterRegex($data[0]) ) {
+        if (self::isFilterRegex($data[0])) {
             $this->buildRegexSQL($data[0], array('value'), $joins, $where);
-        } elseif ( self::isFilterSQL($data[0]) ) {
+        } elseif (self::isFilterSQL($data[0])) {
             $this->buildFilterSQL($data[0], array('value'), $joins, $where);
         } else {
             $parsed = array();
 
             // For the filter provided, loop over each piece
-            foreach ( $data as $string ) {
+            foreach ($data as $string) {
                 $type = self::parseFilter($string);
 
-                if ( $type == self::ERROR ) {
+                if ($type == self::ERROR) {
                     return false;
                 }
 
                 $parsed[$type] = $parsed[$type] ?? array();
 
-                if ( !is_array($parsed[$type]) ) {
+                if (!is_array($parsed[$type])) {
                     $parsed[$type] = array();
                 }
 
                 $parsed[$type][] = $string;
             }
 
-            foreach ( $parsed as $value ) {
+            foreach ($parsed as $value) {
                 $this->buildRangeFilterSQL($value, $joins, $where, $andOperation);
             }
         }
@@ -768,7 +768,7 @@ class FieldDate extends Field implements ExportableField, ImportableField
 
     public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC')
     {
-        if ( $this->isRandomOrder($order) ) {
+        if ($this->isRandomOrder($order)) {
             $sort = 'ORDER BY RAND()';
         } else {
             $sort = sprintf(
@@ -796,13 +796,13 @@ class FieldDate extends Field implements ExportableField, ImportableField
 
     public function groupRecords($records)
     {
-        if ( !is_array($records) || empty($records) ) {
+        if (!is_array($records) || empty($records)) {
             return;
         }
 
         $groups = array('year' => array());
 
-        foreach ( $records as $r ) {
+        foreach ($records as $r) {
             $data = $r->getData($this->get('id'));
 
             $timestamp = DateTimeObj::get('U', $data['value']);
@@ -811,7 +811,7 @@ class FieldDate extends Field implements ExportableField, ImportableField
             $year = $info['year'];
             $month = ($info['mon'] < 10 ? '0' . $info['mon'] : $info['mon']);
 
-            if ( !isset($groups['year'][$year]) ) {
+            if (!isset($groups['year'][$year])) {
                 $groups['year'][$year] = array(
                     'attr' => array('value' => $year),
                     'records' => array(),
@@ -819,11 +819,11 @@ class FieldDate extends Field implements ExportableField, ImportableField
                 );
             }
 
-            if ( !isset($groups['year'][$year]['groups']['month']) ) {
+            if (!isset($groups['year'][$year]['groups']['month'])) {
                 $groups['year'][$year]['groups']['month'] = array();
             }
 
-            if ( !isset($groups['year'][$year]['groups']['month'][$month]) ) {
+            if (!isset($groups['year'][$year]['groups']['month'][$month])) {
                 $groups['year'][$year]['groups']['month'][$month] = array(
                     'attr' => array('value' => $month),
                     'records' => array(),
@@ -843,32 +843,39 @@ class FieldDate extends Field implements ExportableField, ImportableField
 
     public function getExampleFormMarkup()
     {
-        $label = new XMLElement('label', $this->get('label'));
+        $fieldId = $this->get('id');
+        $fieldName = $this->get('element_name');
+
+        $div = new XMLElement('div', null, array('class' => 'form-field'));
+        $label = Widget::Label($this->get('label'));
+        $label->setAttribute('for', $fieldName . '-' . $fieldId);
         if ($this->get('required') === 'yes') {
             $mark = new XMLElement('span', '*');
-            $mark->setAttribute('aria-label', 'Required field');
+            $mark->setAttribute('aria-hidden', 'true');
             $mark->setAttribute('class', 'required-mark');
             $label->appendChild($mark);
         }
 
         $type = 'date';
-        if ( $this->get('time') === 'yes' ) {
+        if ($this->get('time') === 'yes') {
             $type = 'datetime-local';
         }
         $input = Widget::Input('fields['.$this->get('element_name').']', null, $type);
-        if ( $this->get('required') === 'yes' ) {
+        $input->setAttribute('id', $fieldName . '-' . $fieldId);
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
-        if ( $type === 'datetime-local' && $this->get('pre_populate') === 'now' ) {
-            $input->setAttribute('value', '{concat(/data/params/today, \'T\', /data/params/current-time)}');
+        if ($type === 'datetime-local' && $this->get('pre_populate') === 'now') {
+            $input->setAttribute('value', '{concat(/data/params/today, &apos;T&apos;, /data/params/current-time)}');
         }
-        elseif ( $this->get('pre_populate') === 'now' ) {
+        elseif ($this->get('pre_populate') === 'now') {
             $input->setAttribute('value', '{/data/params/today}');
         }
 
-        $label->appendChild($input);
+        $div->appendChild($label);
+        $div->appendChild($input);
 
-        return $label;
+        return $div;
     }
 
 }

--- a/symphony/lib/toolkit/fields/field.email.php
+++ b/symphony/lib/toolkit/fields/field.email.php
@@ -98,7 +98,7 @@ class FieldEmail extends Field
 
     public function commit()
     {
-        if ( !parent::commit() ) return false;
+        if (!parent::commit()) return false;
 
         return FieldManager::saveSettings($this->get('id'), [
             'placeholder' => $this->get('placeholder'),
@@ -116,20 +116,20 @@ class FieldEmail extends Field
         $input = Widget::input("fields{$fieldnamePrefix}[{$this->get('element_name')}]{$fieldnamePostfix}", $value, 'email');
         $input->setAttribute('spellcheck', 'false');
         $input->setAttribute('autocapitalize', 'off');
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
-        if ( $this->get('placeholder') !== null ) {
+        if ($this->get('placeholder') !== null) {
             $input->setAttribute('placeholder', $this->get('placeholder'));
         }
 
         $label = Widget::label($this->get('label'));
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
             $label->appendChild(new XMLElement('i', __('Optional')));
         }
         $label->appendChild($input);
 
-        if ( $flagWithError != null ) {
+        if ($flagWithError != null) {
             $wrapper->appendChild(Widget::Error($label, $flagWithError));
         } else {
             $wrapper->appendChild($label);
@@ -143,7 +143,7 @@ class FieldEmail extends Field
         $element = new XMLElement($this->get('element_name'), $value);
 
         // Return additional attribute 'placeholder'
-        if ( $this->get('placeholder') !== null ) {
+        if ($this->get('placeholder') !== null) {
             $element->setAttribute('placeholder', $this->get('placeholder'));
         }
 
@@ -152,29 +152,35 @@ class FieldEmail extends Field
 
     public function getExampleFormMarkup()
     {
-        $label = new XMLElement('label', $this->get('label'));
+        $fieldId = $this->get('id');
+        $fieldName = $this->get('element_name');
 
+        $div = new XMLElement('div', null, array('class' => 'form-field'));
+        $label = Widget::Label($this->get('label'));
+        $label->setAttribute('for', $fieldName . '-' . $fieldId);
         if ($this->get('required') === 'yes') {
             $mark = new XMLElement('span', '*');
-            $mark->setAttribute('aria-label', 'Required field');
+            $mark->setAttribute('aria-hidden', 'true');
             $mark->setAttribute('class', 'required-mark');
             $label->appendChild($mark);
         }
 
         $input = Widget::input('fields['.$this->get('element_name').']', null, 'email');
+        $input->setAttribute('id', $fieldName . '-' . $fieldId);
         $input->setAttribute('spellcheck', 'false');
         $input->setAttribute('autocapitalize', 'off');
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
-        if ( $this->get('placeholder') !== null ) {
+        if ($this->get('placeholder') !== null) {
             $input->setAttribute('placeholder', $this->get('placeholder'));
         }
         $input->setAttribute('autocomplete', 'email');
 
-        $label->appendChild($input);
+        $div->appendChild($label);
+        $div->appendChild($input);
 
-        return $label;
+        return $div;
     }
 
     public function checkPostFieldData($data, &$message, $entry_id = null)
@@ -185,13 +191,13 @@ class FieldEmail extends Field
         );
         $message = null;
 
-        if ( $this->get('required') === 'yes' && strlen($data) === 0 ) {
+        if ($this->get('required') === 'yes' && strlen($data) === 0) {
             $message = $messages['required'];
             return self::__MISSING_FIELDS__;
         }
 
-        if ( strlen($data) !== 0 ) {
-            if ( !filter_var($data, FILTER_VALIDATE_EMAIL) ) {
+        if (strlen($data) !== 0) {
+            if (!filter_var($data, FILTER_VALIDATE_EMAIL)) {
                 $message = $messages['invalid'];
                 return self::__INVALID_FIELDS__;
             }
@@ -204,7 +210,7 @@ class FieldEmail extends Field
     {
         $status = self::__OK__;
 
-        if ( strlen(trim($data)) == 0 ) return array();
+        if (strlen(trim($data)) == 0) return array();
 
         $result = array(
             'value' => $data
@@ -231,9 +237,9 @@ class FieldEmail extends Field
         $message = $status = null;
         $modes = (object)$this->getImportModes();
 
-        if ( $mode === $modes->getValue ) {
+        if ($mode === $modes->getValue) {
             return $data;
-        } else if ( $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->getPostdata) {
             return $this->processRawFieldData($data, $status, $message, true, $entry_id);
         }
 
@@ -271,7 +277,7 @@ class FieldEmail extends Field
         $modes = (object)$this->getExportModes();
 
         // Export unformatted:
-        if ( $mode === $modes->getUnformatted || $mode === $modes->getPostdata ) {
+        if ($mode === $modes->getUnformatted || $mode === $modes->getPostdata) {
             return isset($data['value'])
                 ? $data['value']
                 : null;
@@ -314,16 +320,16 @@ class FieldEmail extends Field
 
     public function groupRecords($records)
     {
-        if ( !is_array($records) || empty($records) ) return;
+        if (!is_array($records) || empty($records)) return;
 
         $groups = array($this->get('element_name') => array());
 
-        foreach ( $records as $r ) {
+        foreach ($records as $r) {
             $data = $r->getData($this->get('id'));
 
             $value = $data['value'];
 
-            if ( !isset($groups[$this->get('element_name')][$value]) ) {
+            if (!isset($groups[$this->get('element_name')][$value])) {
                 $groups[$this->get('element_name')][$value] = array(
                     'attr' => array('value' => $value),
                     'records' => array(),

--- a/symphony/lib/toolkit/fields/field.input.php
+++ b/symphony/lib/toolkit/fields/field.input.php
@@ -102,10 +102,10 @@ class FieldInput extends Field implements ExportableField, ImportableField
     {
         parent::setFromPOST($settings);
 
-        if ( $this->get('validator') === '' ) {
+        if ($this->get('validator') === '') {
             $this->remove('validator');
         }
-        if ( $this->get('placeholder') === '' ) {
+        if ($this->get('placeholder') === '') {
             $this->remove('placeholder');
         }
     }
@@ -179,10 +179,10 @@ class FieldInput extends Field implements ExportableField, ImportableField
         $type = self::$typeMap[$validator] ?? 'text';
 
         $input = Widget::Input('fields'.$fieldnamePrefix.'['.$this->get('element_name').']'.$fieldnamePostfix, (strlen($value) != 0 ? $value : null), $type);
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
-        if ( $this->get('placeholder') !== null ) {
+        if ($this->get('placeholder') !== null) {
             $input->setAttribute('placeholder', $this->get('placeholder'));
         }
 
@@ -289,10 +289,15 @@ class FieldInput extends Field implements ExportableField, ImportableField
 
     public function getExampleFormMarkup()
     {
-        $label = new XMLElement('label', $this->get('label'));
+        $fieldId = $this->get('id');
+        $fieldName = $this->get('element_name');
+
+        $div = new XMLElement('div', null, array('class' => 'form-field'));
+        $label = Widget::Label($this->get('label'));
+        $label->setAttribute('for', $fieldName . '-' . $fieldId);
         if ($this->get('required') === 'yes') {
             $mark = new XMLElement('span', '*');
-            $mark->setAttribute('aria-label', 'Required field');
+            $mark->setAttribute('aria-hidden', 'true');
             $mark->setAttribute('class', 'required-mark');
             $label->appendChild($mark);
         }
@@ -301,16 +306,18 @@ class FieldInput extends Field implements ExportableField, ImportableField
         $type = self::$typeMap[$validator] ?? 'text';
 
         $input = Widget::input('fields['.$this->get('element_name').']', null, $type);
-        if ( $this->get('required') === 'yes' ) {
+        $input->setAttribute('id', $fieldName . '-' . $fieldId);
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
-        if ( $this->get('placeholder') !== null ) {
+        if ($this->get('placeholder') !== null) {
             $input->setAttribute('placeholder', $this->get('placeholder'));
         }
 
-        $label->appendChild($input);
+        $div->appendChild($label);
+        $div->appendChild($input);
 
-        return $label;
+        return $div;
     }
 
     /*-------------------------------------------------------------------------

--- a/symphony/lib/toolkit/fields/field.month.php
+++ b/symphony/lib/toolkit/fields/field.month.php
@@ -97,7 +97,7 @@ class FieldMonth extends Field
         $default = new XMLElement('label', __('Set current month as value'));
         $default->setAttribute('class', 'column');
         $input = Widget::Input('fields['.$this->get('sortorder').'][default_month]', 'on', 'checkbox');
-        if ( $this->get('default_month') === 'on' ) {
+        if ($this->get('default_month') === 'on') {
             $input->setAttribute('checked', 'checked');
         }
         $default->appendChild($input);
@@ -106,9 +106,6 @@ class FieldMonth extends Field
         $custom = new XMLElement('label', __('Custom month <i>optional</i>'));
         $custom->setAttribute('class', 'column');
         $input = Widget::input('fields['.$this->get('sortorder').'][custom_month]', $this->get('custom_month'), 'month');
-        // Input type="month" is not yet supported by Firefox and Safari
-        $input->setAttribute('placeholder', 'yyyy-mm');
-        $input->setAttribute('aria-label', 'Please enter a month in the format “yyyy-mm”');
         $custom->appendChild($input);
 
         $div = new XMLElement('div', null, array('class' => 'two columns'));
@@ -120,18 +117,12 @@ class FieldMonth extends Field
         $min = new XMLElement('label', __('Earliest year and month to accept <i>optional</i>'));
         $min->setAttribute('class', 'column');
         $input = Widget::input('fields['.$this->get('sortorder').'][min]', $this->get('min'), 'month');
-        // Input type="month" is not yet supported by Firefox and Safari
-        $input->setAttribute('placeholder', 'yyyy-mm');
-        $input->setAttribute('aria-label', 'Please enter a month in the format “yyyy-mm”');
         $min->appendChild($input);
 
         // Max
         $max = new XMLElement('label', __('Latest year and month <i>optional</i>'));
         $max->setAttribute('class', 'column');
         $input = Widget::input('fields['.$this->get('sortorder').'][max]', $this->get('max'), 'month');
-        // Input type="month" is not yet supported by Firefox and Safari
-        $input->setAttribute('placeholder', 'yyyy-mm');
-        $input->setAttribute('aria-label', 'Please enter a month in the format “yyyy-mm”');
         $max->appendChild($input);
 
         $div = new XMLElement('div', null, array('class' => 'two columns'));
@@ -168,7 +159,7 @@ class FieldMonth extends Field
 
     public function commit()
     {
-        if ( !parent::commit() ) return false;
+        if (!parent::commit()) return false;
 
         return FieldManager::saveSettings($this->get('id'), [
             #'default_month' => $this->get('default_month'),
@@ -188,36 +179,44 @@ class FieldMonth extends Field
     {
         $value = isset($data['value']) ? $data['value'] : null;
 
-        $input = Widget::input("fields{$fieldnamePrefix}[{$this->get('element_name')}]{$fieldnamePostfix}", $value, 'month', [
+        $fieldId = $this->get('id');
+        $fieldName = $this->get('element_name');
+
+        $input = Widget::input("fields{$fieldnamePrefix}[{$fieldName}]{$fieldnamePostfix}", $value, 'month', [
             'step' => $this->get('step') ?: 1
         ]);
-        // Input type="month" is not yet supported by Firefox and Safari
-        $input->setAttribute('placeholder', 'yyyy-mm');
-        $input->setAttribute('aria-label', 'Please enter a month in the format “yyyy-mm”');
-        if ( $value === null and $this->get('default_month') === 'on' ) {
+        if ($value === null and $this->get('default_month') === 'on') {
             $input->setAttribute('value', date('Y-m'));
         }
-        else if ( $value === null and $this->get('custom_month') !== null ) {
+        elseif ($value === null and $this->get('custom_month') !== null) {
             $input->setAttribute('value', $this->get('custom_month'));
         }
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
 
-        if ( $this->get('min') !== null ) {
+        if ($this->get('min') !== null) {
             $input->setAttribute('min', $this->get('min'));
         }
-        if ( $this->get('max') !== null ) {
+        if ($this->get('max') !== null) {
             $input->setAttribute('max', $this->get('max'));
         }
 
         $label = Widget::label($this->get('label'));
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
             $label->appendChild(new XMLElement('i', __('Optional')));
         }
-        $label->appendChild($input);
 
-        if ( $flagWithError != null ) {
+        $input->setAttribute('aria-describedby', $fieldName . '-' . $fieldId . '-hint');
+
+        $hint = new XMLElement('small', __('Enter a month (format: yyyy-mm, e.g. 2026-04)'));
+        $hint->setAttribute('class', 'help field-hint');
+        $hint->setAttribute('id', $fieldName . '-' . $fieldId . '-hint');
+
+        $label->appendChild($input);
+        $label->appendChild($hint);
+
+        if ($flagWithError != null) {
             $wrapper->appendChild(Widget::Error($label, $flagWithError));
         } else {
             $wrapper->appendChild($label);
@@ -231,15 +230,15 @@ class FieldMonth extends Field
         $element = new XMLElement($this->get('element_name'), $value);
 
         // Return additional attributes 'min', 'max' and 'step'
-        if ( $this->get('min') !== null ) {
+        if ($this->get('min') !== null) {
             $element->setAttribute('min', $this->get('min'));
         }
 
-        if ( $this->get('max') !== null ) {
+        if ($this->get('max') !== null) {
             $element->setAttribute('max', $this->get('max'));
         }
 
-        if ( $this->get('step') !== null ) {
+        if ($this->get('step') !== null) {
             $element->setAttribute('step', $this->get('step'));
         }
 
@@ -248,11 +247,16 @@ class FieldMonth extends Field
 
     public function getExampleFormMarkup()
     {
-        $labelText = $this->get('label') . "\n<!-- Input type=\"month\" is not yet supported by Firefox and Safari. Use placeholder and aria-label to help users enter a valid value. -->";
-        $label = new XMLElement('label', $labelText);
+        $fieldId = $this->get('id');
+        $fieldName = $this->get('element_name');
+
+        $div = new XMLElement('div', __("\n<!-- input[type=\"month\"] may fall back to a text field in some browsers. A format hint is included to ensure valid input. -->"), array('class' => 'form-field'));
+
+        $label = Widget::Label($this->get('label'));
+        $label->setAttribute('for', $fieldName . '-' . $fieldId);
         if ($this->get('required') === 'yes') {
             $mark = new XMLElement('span', '*');
-            $mark->setAttribute('aria-label', 'Required field');
+            $mark->setAttribute('aria-hidden', 'true');
             $mark->setAttribute('class', 'required-mark');
             $label->appendChild($mark);
         }
@@ -260,29 +264,35 @@ class FieldMonth extends Field
         $input = Widget::input('fields['.$this->get('element_name').']', null, 'month', [
             'step' => $this->get('step') ?: 1
         ]);
-        // Input type="month" is not yet supported by Firefox and Safari
-        $input->setAttribute('placeholder', 'yyyy-mm');
-        $input->setAttribute('aria-label', 'Please enter a month in the format “yyyy-mm”');
-        if ( $this->get('custom_month') !== null ) {
+        $input->setAttribute('id', $fieldName . '-' . $fieldId);
+        if ($this->get('custom_month') !== null) {
             $input->setAttribute('value', $this->get('custom_month'));
         }
-        if ( $this->get('default_month') === 'on' ) {
-            $input->setAttribute('value', '{concat(/data/params/this-year, \'-\', /data/params/this-month)}');
+        if ($this->get('default_month') === 'on') {
+            $input->setAttribute('value', '{concat(/data/params/this-year, &apos;-&apos;, /data/params/this-month)}');
         }
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
 
-        if ( $this->get('min') !== null ) {
+        if ($this->get('min') !== null) {
             $input->setAttribute('min', $this->get('min'));
         }
-        if ( $this->get('max') !== null ) {
+        if ($this->get('max') !== null) {
             $input->setAttribute('max', $this->get('max'));
         }
 
-        $label->appendChild($input);
+        $input->setAttribute('aria-describedby', $fieldName . '-' . $fieldId . '-hint');
 
-        return $label;
+        $hint = new XMLElement('small', __('Enter a month (format: yyyy-mm, e.g. 2026-04)'));
+        $hint->setAttribute('class', 'field-hint');
+        $hint->setAttribute('id', $fieldName . '-' . $fieldId . '-hint');
+
+        $div->appendChild($label);
+        $div->appendChild($input);
+        $div->appendChild($hint);
+
+        return $div;
     }
 
     public function checkPostFieldData($data, &$message, $entry_id = null)
@@ -301,32 +311,32 @@ class FieldMonth extends Field
         $message = null;
 
 
-        if ( $this->get('required') === 'yes' && strlen($data) === 0 ) {
+        if ($this->get('required') === 'yes' && strlen($data) === 0) {
             $message = $messages['required'];
             return self::__MISSING_FIELDS__;
         }
 
-        if ( strlen($data) > 0 && !preg_match('/^\d{4}-(0[1-9]|1[0-2])$/', $data) ) {
+        if (strlen($data) > 0 && !preg_match('/^\d{4}-(0[1-9]|1[0-2])$/', $data)) {
             $message = $messages['invalid'];
             return self::__INVALID_FIELDS__;
         }
 
-        if ( preg_match('/^\d{4}-(0[1-9]|1[0-2])$/', $data) ) {
-            if ( strlen($data) > 0 && $data < $min ) {
+        if (preg_match('/^\d{4}-(0[1-9]|1[0-2])$/', $data)) {
+            if (strlen($data) > 0 && $data < $min) {
                 $message = $messages['min'];
                 return self::__INVALID_FIELDS__;
             }
 
-            if ( strlen($data) > 0 && $data > $max ) {
+            if (strlen($data) > 0 && $data > $max) {
                 $message = $messages['max'];
                 return self::__INVALID_FIELDS__;
             }
 
-            if ( $step !== 'any' && $step > 1 ) {
+            if ($step !== 'any' && $step > 1) {
                 $tmpData = static::getSortableMonthValue($data);
                 $tmpMin = static::getSortableMonthValue($min);
                 $relative =  $tmpData - $tmpMin;
-                if ( fmod($relative, $step) !== 0.0 ) {
+                if (fmod($relative, $step) !== 0.0) {
 
                     $message = $messages['step'];
                     return self::__INVALID_FIELDS__;
@@ -341,7 +351,7 @@ class FieldMonth extends Field
     {
         $status = self::__OK__;
 
-        if ( strlen(trim($data)) == 0 ) return array();
+        if (strlen(trim($data)) == 0) return array();
 
         $result = array(
             'value' => $data
@@ -367,9 +377,9 @@ class FieldMonth extends Field
         $message = $status = null;
         $modes = (object)$this->getImportModes();
 
-        if ( $mode === $modes->getValue ) {
+        if ($mode === $modes->getValue) {
             return $data;
-        } else if ( $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->getPostdata) {
             return $this->processRawFieldData($data, $status, $message, true, $entry_id);
         }
 
@@ -407,7 +417,7 @@ class FieldMonth extends Field
         $modes = (object)$this->getExportModes();
 
         // Export unformatted:
-        if ( $mode === $modes->getUnformatted || $mode === $modes->getPostdata ) {
+        if ($mode === $modes->getUnformatted || $mode === $modes->getPostdata) {
             return isset($data['value'])
                 ? $data['value']
                 : null;
@@ -499,16 +509,16 @@ class FieldMonth extends Field
 
     public function groupRecords($records)
     {
-        if ( !is_array($records) || empty($records) ) return;
+        if (!is_array($records) || empty($records)) return;
 
         $groups = array($this->get('element_name') => array());
 
-        foreach ( $records as $r ) {
+        foreach ($records as $r) {
             $data = $r->getData($this->get('id'));
 
             $value = $data['value'];
 
-            if ( !isset($groups[$this->get('element_name')][$value]) ) {
+            if (!isset($groups[$this->get('element_name')][$value])) {
                 $groups[$this->get('element_name')][$value] = array(
                     'attr' => array('value' => $value),
                     'records' => array(),

--- a/symphony/lib/toolkit/fields/field.radio.php
+++ b/symphony/lib/toolkit/fields/field.radio.php
@@ -37,19 +37,19 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
     {
         $values = preg_split('/,\s*/i', $this->get('static_options'), -1, PREG_SPLIT_NO_EMPTY);
 
-        if ( $this->get('dynamic_options') != '' ) {
+        if ($this->get('dynamic_options') != '') {
             $this->findAndAddDynamicOptions($values);
         }
 
         $values = array_map('trim', $values);
         // Fixes issues on PHP5.3. RE: #1773 ^BA
-        if ( empty($values) ) {
+        if (empty($values)) {
             return $values;
         }
 
         $states = array_combine($values, $values);
 
-        if ( $this->get('sort_options') === 'yes' ) {
+        if ($this->get('sort_options') === 'yes') {
             natsort($states);
         }
 
@@ -127,19 +127,19 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
 
     public function findAndAddDynamicOptions(&$values)
     {
-        if ( !is_array($values) ) {
+        if (!is_array($values)) {
             $values = array();
         }
 
         $results = false;
 
         // Fixes #1802
-        if ( !Symphony::Database()->tableExists('tbl_entries_data_' . $this->get('dynamic_options')) ) {
+        if (!Symphony::Database()->tableExists('tbl_entries_data_' . $this->get('dynamic_options'))) {
             return;
         }
 
         // Ensure that the table has a 'value' column
-        if ( (boolean)Symphony::Database()->fetchVar('Field', 0, sprintf(
+        if ((boolean)Symphony::Database()->fetchVar('Field', 0, sprintf(
             "SHOW COLUMNS FROM `tbl_entries_data_%d` LIKE '%s'",
             $this->get('dynamic_options'),
             'value'
@@ -153,7 +153,7 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
         }
 
         // In the case of a Upload field, use 'file' instead of 'value'
-        if ( ($results == false) && (boolean)Symphony::Database()->fetchVar('Field', 0, sprintf(
+        if (($results == false) && (boolean)Symphony::Database()->fetchVar('Field', 0, sprintf(
             "SHOW COLUMNS FROM `tbl_entries_data_%d` LIKE '%s'",
             $this->get('dynamic_options'),
             'file'
@@ -166,8 +166,8 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
             ));
         }
 
-        if ( $results ) {
-            if ( $this->get('sort_options') == 'no' ) {
+        if ($results) {
+            if ($this->get('sort_options') == 'no') {
                 natsort($results);
             }
 
@@ -181,15 +181,15 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
 
     public function findDefaults(array &$settings)
     {
-        if ( !isset($settings['display_inline']) ) {
+        if (!isset($settings['display_inline'])) {
             $settings['display_inline'] = 'no';
         }
 
-        if ( !isset($settings['show_association']) ) {
+        if (!isset($settings['show_association'])) {
             $settings['show_association'] = 'no';
         }
 
-        if ( !isset($settings['sort_options']) ) {
+        if (!isset($settings['sort_options'])) {
             $settings['sort_options'] = 'no';
         }
     }
@@ -218,7 +218,7 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
             array('', false, __('None'))
         );
 
-        if ( $this->get('dynamic_options') ) {
+        if ($this->get('dynamic_options')) {
             $options[] = array($this->get('dynamic_options'));
         }
 
@@ -228,7 +228,7 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
             ))
         );
 
-        if ( isset($errors['dynamic_options']) ) {
+        if (isset($errors['dynamic_options'])) {
             $div->appendChild(Widget::Error($label, $errors['dynamic_options']));
         } else {
             $div->appendChild($label);
@@ -259,11 +259,11 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
 
     public function checkFields(array &$errors, $checkForDuplicates = true)
     {
-        if ( !is_array($errors) ) {
+        if (!is_array($errors)) {
             $errors = array();
         }
 
-        if ( $this->get('static_options') == '' && ($this->get('dynamic_options') == '' || $this->get('dynamic_options') == 'none') ) {
+        if ($this->get('static_options') == '' && ($this->get('dynamic_options') == '' || $this->get('dynamic_options') == 'none')) {
             $errors['dynamic_options'] = __('At least one source must be specified, dynamic or static.');
         }
 
@@ -272,30 +272,30 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
 
     public function commit()
     {
-        if ( !Field::commit() ) {
+        if (!Field::commit()) {
             return false;
         }
 
         $id = $this->get('id');
 
-        if ( $id === false ) {
+        if ($id === false) {
             return false;
         }
 
         $fields = array();
 
-        if ( $this->get('static_options') != '' ) {
+        if ($this->get('static_options') != '') {
             $fields['static_options'] = $this->get('static_options');
         }
 
-        if ( $this->get('dynamic_options') != '' ) {
+        if ($this->get('dynamic_options') != '') {
             $fields['dynamic_options'] = $this->get('dynamic_options');
         }
 
         $fields['display_inline'] = ($this->get('display_inline') ? $this->get('display_inline') : 'no');
         $fields['sort_options'] = $this->get('sort_options') === 'yes' ? 'yes' : 'no';
 
-        if ( !FieldManager::saveSettings($id, $fields) ) {
+        if (!FieldManager::saveSettings($id, $fields)) {
             return false;
         }
 
@@ -304,7 +304,7 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
         // Dynamic Options isn't an array like in Select Box Link
         $field_id = $this->get('dynamic_options');
 
-        if ( !is_null($field_id) && is_numeric($field_id) ) {
+        if (!is_null($field_id) && is_numeric($field_id)) {
             SectionManager::createSectionAssociation(null, $id, (int)$field_id, $this->get('show_association') === 'yes' ? true : false, $this->get('association_ui'), $this->get('association_editor'));
         }
 
@@ -320,13 +320,13 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
         $states = $this->getToggleStates();
         $value = isset($data['value']) ? $data['value'] : null;
 
-        if ( !is_array($value) ) {
+        if (!is_array($value)) {
             $value = array($value);
         }
 
         $options = array();
 
-        foreach ( $states as $handle => $v ) {
+        foreach ($states as $handle => $v) {
             $options[] = array(General::sanitize($v), in_array($v, $value), General::sanitize($v));
         }
 
@@ -336,21 +336,21 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
         $legend = new XMLElement('legend', $this->get('label'));
         $fieldset->appendChild($legend);
 
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
             $legend->appendChild(new XMLElement('i', __('Optional')));
         }
 
         $i = 0;
         // Create the radio buttons
-        if ( $this->get('display_inline') === 'yes' ) {
+        if ($this->get('display_inline') === 'yes') {
             foreach ($options as $opt) {
                 $i++;
                 $radio = Widget::input($fieldname, $opt[0], 'radio'); // Value
                 $radio->setAttribute('id', $this->get('element_name') . 'Choice' . $i);
-                if ( $this->get('required') === 'yes' ) {
+                if ($this->get('required') === 'yes') {
                     $radio->setAttribute('required', 'required');
                 }
-                if ( $opt[1] === true ) {
+                if ($opt[1] === true) {
                     $radio->setAttribute('checked', 'checked');
                 }
 
@@ -366,10 +366,10 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
             foreach ($options as $opt) {
                 $label = new XMLElement('label');
                 $radio = Widget::input($fieldname, $opt[0], 'radio'); // Value
-                if ( $this->get('required') === 'yes' ) {
+                if ($this->get('required') === 'yes') {
                     $radio->setAttribute('required', 'required');
                 }
-                if ( $opt[1] === true ) {
+                if ($opt[1] === true) {
                     $radio->setAttribute('checked', 'checked');
                 }
 
@@ -382,7 +382,7 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
             }
         }
 
-        if ( $flagWithError != null ) {
+        if ($flagWithError != null) {
             $wrapper->appendChild(Widget::Error($fieldset, $flagWithError));
         } else {
             $wrapper->appendChild($fieldset);
@@ -398,14 +398,14 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
     {
         $status = self::__OK__;
 
-        if ( !is_array($data) ) {
+        if (!is_array($data)) {
             return array(
                 'value' => $data,
                 'handle' => Lang::createHandle($data)
             );
         }
 
-        if ( empty($data) ) {
+        if (empty($data)) {
             return null;
         }
 
@@ -414,7 +414,7 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
             'handle' => array()
         );
 
-        foreach ( $data as $value ) {
+        foreach ($data as $value) {
             $result['value'][] = $value;
             $result['handle'][] = Lang::createHandle($value);
         }
@@ -442,17 +442,17 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
         $message = $status = null;
         $modes = (object)$this->getImportModes();
 
-        if ( !is_array($data) ) {
+        if (!is_array($data)) {
             $data = array($data);
         }
 
-        if ( $mode === $modes->getValue ) {
-            if ( $this->get('display_inline') === 'no' ) {
+        if ($mode === $modes->getValue) {
+            if ($this->get('display_inline') === 'no') {
                 $data = array(implode('', $data));
             }
 
             return $data;
-        } elseif ( $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->getPostdata) {
             return $this->processRawFieldData($data, $status, $message, true, $entry_id);
         }
 
@@ -495,32 +495,32 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
     {
         $modes = (object)$this->getExportModes();
 
-        if ( isset($data['handle']) && is_array($data['handle']) === false ) {
+        if (isset($data['handle']) && is_array($data['handle']) === false) {
             $data['handle'] = array(
                 $data['handle']
             );
         }
 
-        if ( isset($data['value']) && is_array($data['value']) === false ) {
+        if (isset($data['value']) && is_array($data['value']) === false) {
             $data['value'] = array(
                 $data['value']
             );
         }
 
         // Handle => Value pairs:
-        if ( $mode === $modes->listHandleToValue ) {
+        if ($mode === $modes->listHandleToValue) {
             return isset($data['handle'], $data['value'])
                 ? array_combine($data['handle'], $data['value'])
                 : array();
 
             // Array of handles:
-        } elseif ( $mode === $modes->listHandle ) {
+        } elseif ($mode === $modes->listHandle) {
             return isset($data['handle'])
                 ? $data['handle']
                 : array();
 
             // Array of values:
-        } elseif ( $mode === $modes->listValue || $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->listValue || $mode === $modes->getPostdata) {
             return isset($data['value'])
                 ? $data['value']
                 : array();
@@ -535,12 +535,12 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
     {
         $existing_options = $this->getToggleStates();
 
-        if ( is_array($existing_options) && !empty($existing_options) ) {
+        if (is_array($existing_options) && !empty($existing_options)) {
             $optionlist = new XMLElement('ul');
             $optionlist->setAttribute('class', 'tags');
             $optionlist->setAttribute('data-interactive', 'data-interactive');
 
-            foreach ( $existing_options as $option ) {
+            foreach ($existing_options as $option) {
                 $optionlist->appendChild(
                     new XMLElement('li', General::sanitize($option))
                 );
@@ -556,22 +556,22 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
 
     public function groupRecords($records)
     {
-        if ( !is_array($records) || empty($records) ) {
+        if (!is_array($records) || empty($records)) {
             return;
         }
 
         $groups = array($this->get('element_name') => array());
 
-        foreach ( $records as $r ) {
+        foreach ($records as $r) {
             $data = $r->getData($this->get('id'));
 
-            if ( !isset($data['value']) ) continue;
+            if (!isset($data['value'])) continue;
 
-            if ( is_array($data['value']) ) {
-                foreach ( $data['value'] as $key => $v ) {
+            if (is_array($data['value'])) {
+                foreach ($data['value'] as $key => $v) {
                     $value = General::sanitize($v);
 
-                    if ( !isset($groups[$this->get('element_name')][$data['handle'][$key]]) ) {
+                    if (!isset($groups[$this->get('element_name')][$data['handle'][$key]])) {
                         $groups[$this->get('element_name')][$data['handle'][$key]] = array(
                             'attr' => array('handle' => $data['handle'][$key], 'value' => $value),
                             'records' => array(),
@@ -585,7 +585,7 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
             else {
                 $value = General::sanitize($data['value']);
 
-                if ( !isset($groups[$this->get('element_name')][$data['handle']]) ) {
+                if (!isset($groups[$this->get('element_name')][$data['handle']])) {
                     $groups[$this->get('element_name')][$data['handle']] = array(
                         'attr' => array('handle' => $data['handle'], 'value' => $value),
                         'records' => array(),
@@ -610,39 +610,41 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
 
         $options = array();
 
-        foreach ( $states as $handle => $v ) {
+        foreach ($states as $handle => $v) {
             $options[] = array($v, null, $v);
         }
+
+        $div = new XMLElement('div', null, array('class' => 'form-field'));
 
         $fieldname = 'fields['.$this->get('element_name').']';
 
         $fieldset = new XMLElement('fieldset');
-        if ( $this->get('display_inline') === 'yes' ) {
-            $fieldset->setValue("\n" . '<!-- Displayed horizontally -->');
+        if ($this->get('display_inline') === 'yes') {
+            $fieldset->setValue("\n" . __('<!-- Displayed horizontally -->'));
         } else {
-            $fieldset->setValue("\n" . '<!-- Displayed vertically -->');
+            $fieldset->setValue("\n" . __('<!-- Displayed vertically -->'));
         }
         $legend = new XMLElement('legend', $this->get('label'));
         $fieldset->appendChild($legend);
 
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $mark = new XMLElement('span', '*');
-            $mark->setAttribute('aria-label', 'Required field');
+            $mark->setAttribute('aria-hidden', 'true');
             $mark->setAttribute('class', 'required-mark');
             $legend->appendChild($mark);
         }
 
         $i = 0;
         // Create the radio buttons
-        if ( $this->get('display_inline') === 'yes' ) {
+        if ($this->get('display_inline') === 'yes') {
             foreach ($options as $opt) {
                 $i++;
                 $radio = Widget::input($fieldname, $opt[0], 'radio'); // Value
                 $radio->setAttribute('id', $this->get('element_name') . 'Choice' . $i);
-                if ( $this->get('required') === 'yes' ) {
+                if ($this->get('required') === 'yes') {
                     $radio->setAttribute('required', 'required');
                 }
-                if ( $opt[1] === true ) {
+                if ($opt[1] === true) {
                     $radio->setAttribute('checked', 'checked');
                 }
 
@@ -658,10 +660,10 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
             foreach ($options as $opt) {
                 $label = new XMLElement('label');
                 $radio = Widget::input($fieldname, $opt[0], 'radio'); // Value
-                if ( $this->get('required') === 'yes' ) {
+                if ($this->get('required') === 'yes') {
                     $radio->setAttribute('required', 'required');
                 }
-                if ( $opt[1] === true ) {
+                if ($opt[1] === true) {
                     $radio->setAttribute('checked', 'checked');
                 }
 
@@ -674,6 +676,8 @@ class FieldRadio extends FieldTagList implements ExportableField, ImportableFiel
             }
         }
 
-        return $fieldset;
+        $div->appendChild($fieldset);
+
+        return $div;
     }
 }

--- a/symphony/lib/toolkit/fields/field.range.php
+++ b/symphony/lib/toolkit/fields/field.range.php
@@ -129,7 +129,7 @@ class FieldRange extends Field implements ExportableField, ImportableField
 
     public function commit()
     {
-        if ( !parent::commit() ) return false;
+        if (!parent::commit()) return false;
 
         return FieldManager::saveSettings($this->get('id'), [
             'min' => $this->get('min'),
@@ -147,30 +147,29 @@ class FieldRange extends Field implements ExportableField, ImportableField
         $value = isset($data['value']) ? $data['value'] : null;
 
         $input = Widget::input("fields{$fieldnamePrefix}[{$this->get('element_name')}]{$fieldnamePostfix}", $value, 'range');
-        if ( $this->get('required') === 'yes' ) {
-            $input->setAttribute('required', 'required');
-        }
+        // `range` inputs always have a value and cannot be empty.
+        // The `required` attribute is therefore not applicable.
 
         // Return additional attributes 'min', 'max' and 'step'
-        if ( $this->get('min') !== null ) {
+        if ($this->get('min') !== null) {
             $input->setAttribute('min', $this->get('min'));
         }
 
-        if ( $this->get('max') !== null ) {
+        if ($this->get('max') !== null) {
             $input->setAttribute('max', $this->get('max'));
         }
 
-        if ( $this->get('step') !== null ) {
+        if ($this->get('step') !== null) {
             $input->setAttribute('step', $this->get('step'));
         }
 
         $label = Widget::label($this->get('label'));
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
             $label->appendChild(new XMLElement('i', __('Optional')));
         }
         $label->appendChild($input);
 
-        if ( $flagWithError != null ) {
+        if ($flagWithError != null) {
             $wrapper->appendChild(Widget::Error($label, $flagWithError));
         } else {
             $wrapper->appendChild($label);
@@ -184,15 +183,15 @@ class FieldRange extends Field implements ExportableField, ImportableField
         $element = new XMLElement($this->get('element_name'), $value);
 
         // Return additional attributes 'min', 'max' and 'step'
-        if ( $this->get('min') !== null ) {
+        if ($this->get('min') !== null) {
             $element->setAttribute('min', $this->get('min'));
         }
 
-        if ( $this->get('max') !== null ) {
+        if ($this->get('max') !== null) {
             $element->setAttribute('max', $this->get('max'));
         }
 
-        if ( $this->get('step') !== null ) {
+        if ($this->get('step') !== null) {
             $element->setAttribute('step', $this->get('step'));
         }
 
@@ -201,35 +200,41 @@ class FieldRange extends Field implements ExportableField, ImportableField
 
     public function getExampleFormMarkup()
     {
-        $label = new XMLElement('label', $this->get('label'));
+        $fieldId = $this->get('id');
+        $fieldName = $this->get('element_name');
+
+        $div = new XMLElement('div', null, array('class' => 'form-field'));
+        $label = Widget::Label($this->get('label'));
+        $label->setAttribute('for', $fieldName . '-' . $fieldId);
         if ($this->get('required') === 'yes') {
             $mark = new XMLElement('span', '*');
-            $mark->setAttribute('aria-label', 'Required field');
+            $mark->setAttribute('aria-hidden', 'true');
             $mark->setAttribute('class', 'required-mark');
             $label->appendChild($mark);
         }
 
-        $input = Widget::input('fields['.$this->get('element_name').']', null, 'range');
-        if ( $this->get('required') === 'yes' ) {
-            $input->setAttribute('required', 'required');
-        }
+        $input = Widget::input('fields[' . $fieldName . ']', null, 'range');
+        $input->setAttribute('id', $fieldName . '-' . $fieldId);
+        // `range` inputs always have a value and cannot be empty.
+        // The `required` attribute is therefore not applicable.
 
         // Return additional attributes 'min', 'max' and 'step'
-        if ( $this->get('min') !== null ) {
+        if ($this->get('min') !== null) {
             $input->setAttribute('min', $this->get('min'));
         }
 
-        if ( $this->get('max') !== null ) {
+        if ($this->get('max') !== null) {
             $input->setAttribute('max', $this->get('max'));
         }
 
-        if ( $this->get('step') !== null ) {
+        if ($this->get('step') !== null) {
             $input->setAttribute('step', $this->get('step'));
         }
 
-        $label->appendChild($input);
+        $div->appendChild($label);
+        $div->appendChild($input);
 
-        return $label;
+        return $div;
     }
 
     public function checkPostFieldData($data, &$message, $entry_id = null)
@@ -247,28 +252,28 @@ class FieldRange extends Field implements ExportableField, ImportableField
         );
         $message = NULL;
 
-        if ( $this->get('required') == 'yes' && strlen($data) === 0 ) {
+        if ($this->get('required') == 'yes' && strlen($data) === 0) {
             $message = $messages['required'];
             return self::__MISSING_FIELDS__;
         }
 
-        if ( strlen($data) > 0 && !is_numeric($data) ) {
+        if (strlen($data) > 0 && !is_numeric($data)) {
             $message = $messages['invalid'];
             return self::__INVALID_FIELDS__;
         }
 
-        if ( is_numeric($data) ) {
-            if ( is_numeric($min) && $data < $min ) {
+        if (is_numeric($data)) {
+            if (is_numeric($min) && $data < $min) {
                 $message = $messages['min'];
                 return self::__INVALID_FIELDS__;
             }
 
-            if ( is_numeric($max) && $data > $max ) {
+            if (is_numeric($max) && $data > $max) {
                 $message = $messages['max'];
                 return self::__INVALID_FIELDS__;
             }
 
-            if ( is_numeric($step) && $step > 0 ) {
+            if (is_numeric($step) && $step > 0) {
                 $relative = $data - $min;
                 if (fmod($relative, $step) !== 0.0) {
                     $message = $messages['step'];
@@ -284,7 +289,7 @@ class FieldRange extends Field implements ExportableField, ImportableField
     {
         $status = self::__OK__;
 
-        if ( strlen(trim($data)) == 0 ) return array();
+        if (strlen(trim($data)) == 0) return array();
 
         $result = array(
             'value' => $data
@@ -310,9 +315,9 @@ class FieldRange extends Field implements ExportableField, ImportableField
         $message = $status = null;
         $modes = (object)$this->getImportModes();
 
-        if ( $mode === $modes->getValue ) {
+        if ($mode === $modes->getValue) {
             return $data;
-        } else if ( $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->getPostdata) {
             return $this->processRawFieldData($data, $status, $message, true, $entry_id);
         }
 
@@ -350,7 +355,7 @@ class FieldRange extends Field implements ExportableField, ImportableField
         $modes = (object)$this->getExportModes();
 
         // Export unformatted:
-        if ( $mode === $modes->getUnformatted || $mode === $modes->getPostdata ) {
+        if ($mode === $modes->getUnformatted || $mode === $modes->getPostdata) {
             return isset($data['value'])
                 ? $data['value']
                 : null;
@@ -410,7 +415,7 @@ class FieldRange extends Field implements ExportableField, ImportableField
         $expression = " `t$field_id`.`value` ";
 
         // X to Y support
-        if ( preg_match('/^(-?(?:\d+(?:\.\d+)?|\.\d+)) to (-?(?:\d+(?:\.\d+)?|\.\d+))$/i', $data[0], $match) ) {
+        if (preg_match('/^(-?(?:\d+(?:\.\d+)?|\.\d+)) to (-?(?:\d+(?:\.\d+)?|\.\d+))$/i', $data[0], $match)) {
 
             $joins .= " LEFT JOIN `tbl_entries_data_$field_id` AS `t$field_id` ON (`e`.`id` = `t$field_id`.entry_id) ";
             $where .= " AND CAST(`t$field_id`.`value` AS FLOAT) BETWEEN {$match[1]} AND {$match[2]} ";
@@ -419,7 +424,7 @@ class FieldRange extends Field implements ExportableField, ImportableField
         }
 
         // Equal to or less/greater than X
-        else if ( preg_match('/^(equal to or )?(less|greater) than\s*(-?(?:\d+(?:\.\d+)?|\.\d+))$/i', $data[0], $match) ) {
+        elseif (preg_match('/^(equal to or )?(less|greater) than\s*(-?(?:\d+(?:\.\d+)?|\.\d+))$/i', $data[0], $match)) {
 
             switch($match[2]) {
                 case 'less':
@@ -431,7 +436,7 @@ class FieldRange extends Field implements ExportableField, ImportableField
                     break;
             }
 
-            if ( $match[1] ) {
+            if ($match[1]) {
                 $expression .= '=';
             }
 
@@ -443,7 +448,7 @@ class FieldRange extends Field implements ExportableField, ImportableField
         }
 
         // Look for <=/< or >=/> symbols
-        else if ( preg_match('/^(=?[<>]=?)\s*(-?(?:\d+(?:\.\d+)?|\.\d+))$/i', $data[0], $match) ) {
+        elseif (preg_match('/^(=?[<>]=?)\s*(-?(?:\d+(?:\.\d+)?|\.\d+))$/i', $data[0], $match)) {
 
             $joins .= " LEFT JOIN `tbl_entries_data_$field_id` AS `t$field_id` ON (`e`.`id` = `t$field_id`.entry_id) ";
             $where .= sprintf(
@@ -466,16 +471,16 @@ class FieldRange extends Field implements ExportableField, ImportableField
 
     public function groupRecords($records)
     {
-        if ( !is_array($records) || empty($records) ) return;
+        if (!is_array($records) || empty($records)) return;
 
         $groups = array($this->get('element_name') => array());
 
-        foreach ( $records as $r ) {
+        foreach ($records as $r) {
             $data = $r->getData($this->get('id'));
 
             $value = $data['value'];
 
-            if ( !isset($groups[$this->get('element_name')][$value]) ) {
+            if (!isset($groups[$this->get('element_name')][$value])) {
                 $groups[$this->get('element_name')][$value] = array(
                     'attr' => array('value' => $value),
                     'records' => array(),

--- a/symphony/lib/toolkit/fields/field.select.php
+++ b/symphony/lib/toolkit/fields/field.select.php
@@ -36,19 +36,19 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
     {
         $values = preg_split('/,\s*/i', $this->get('static_options'), -1, PREG_SPLIT_NO_EMPTY);
 
-        if ( $this->get('dynamic_options') != '' ) {
+        if ($this->get('dynamic_options') != '') {
             $this->findAndAddDynamicOptions($values);
         }
 
         $values = array_map('trim', $values);
         // Fixes issues on PHP5.3. RE: #1773 ^BA
-        if ( empty($values) ) {
+        if (empty($values)) {
             return $values;
         }
 
         $states = array_combine($values, $values);
 
-        if ( $this->get('sort_options') === 'yes' ) {
+        if ($this->get('sort_options') === 'yes') {
             natsort($states);
         }
 
@@ -126,19 +126,19 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
 
     public function findAndAddDynamicOptions(&$values)
     {
-        if ( !is_array($values) ) {
+        if (!is_array($values)) {
             $values = array();
         }
 
         $results = false;
 
         // Fixes #1802
-        if ( !Symphony::Database()->tableExists('tbl_entries_data_' . $this->get('dynamic_options')) ) {
+        if (!Symphony::Database()->tableExists('tbl_entries_data_' . $this->get('dynamic_options'))) {
             return;
         }
 
         // Ensure that the table has a 'value' column
-        if ( (boolean)Symphony::Database()->fetchVar('Field', 0, sprintf(
+        if ((boolean)Symphony::Database()->fetchVar('Field', 0, sprintf(
             "SHOW COLUMNS FROM `tbl_entries_data_%d` LIKE '%s'",
             $this->get('dynamic_options'),
             'value'
@@ -152,7 +152,7 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
         }
 
         // In the case of a Upload field, use 'file' instead of 'value'
-        if ( ($results == false) && (boolean)Symphony::Database()->fetchVar('Field', 0, sprintf(
+        if (($results == false) && (boolean)Symphony::Database()->fetchVar('Field', 0, sprintf(
             "SHOW COLUMNS FROM `tbl_entries_data_%d` LIKE '%s'",
             $this->get('dynamic_options'),
             'file'
@@ -165,8 +165,8 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
             ));
         }
 
-        if ( $results ) {
-            if ( $this->get('sort_options') == 'no' ) {
+        if ($results) {
+            if ($this->get('sort_options') == 'no') {
                 natsort($results);
             }
 
@@ -180,15 +180,15 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
 
     public function findDefaults(array &$settings)
     {
-        if ( !isset($settings['allow_multiple_selection']) ) {
+        if (!isset($settings['allow_multiple_selection'])) {
             $settings['allow_multiple_selection'] = 'no';
         }
 
-        if ( !isset($settings['show_association']) ) {
+        if (!isset($settings['show_association'])) {
             $settings['show_association'] = 'no';
         }
 
-        if ( !isset($settings['sort_options']) ) {
+        if (!isset($settings['sort_options'])) {
             $settings['sort_options'] = 'no';
         }
     }
@@ -217,7 +217,7 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
             array('', false, __('None'))
         );
 
-        if ( $this->get('dynamic_options') ) {
+        if ($this->get('dynamic_options')) {
             $options[] = array($this->get('dynamic_options'));
         }
 
@@ -227,7 +227,7 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
             ))
         );
 
-        if ( isset($errors['dynamic_options']) ) {
+        if (isset($errors['dynamic_options'])) {
             $div->appendChild(Widget::Error($label, $errors['dynamic_options']));
         } else {
             $div->appendChild($label);
@@ -258,11 +258,11 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
 
     public function checkFields(array &$errors, $checkForDuplicates = true)
     {
-        if ( !is_array($errors) ) {
+        if (!is_array($errors)) {
             $errors = array();
         }
 
-        if ( $this->get('static_options') == '' && ($this->get('dynamic_options') == '' || $this->get('dynamic_options') == 'none') ) {
+        if ($this->get('static_options') == '' && ($this->get('dynamic_options') == '' || $this->get('dynamic_options') == 'none')) {
             $errors['dynamic_options'] = __('At least one source must be specified, dynamic or static.');
         }
 
@@ -271,30 +271,30 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
 
     public function commit()
     {
-        if ( !Field::commit() ) {
+        if (!Field::commit()) {
             return false;
         }
 
         $id = $this->get('id');
 
-        if ( $id === false ) {
+        if ($id === false) {
             return false;
         }
 
         $fields = array();
 
-        if ( $this->get('static_options') != '' ) {
+        if ($this->get('static_options') != '') {
             $fields['static_options'] = $this->get('static_options');
         }
 
-        if ( $this->get('dynamic_options') != '' ) {
+        if ($this->get('dynamic_options') != '') {
             $fields['dynamic_options'] = $this->get('dynamic_options');
         }
 
         $fields['allow_multiple_selection'] = ($this->get('allow_multiple_selection') ? $this->get('allow_multiple_selection') : 'no');
         $fields['sort_options'] = $this->get('sort_options') === 'yes' ? 'yes' : 'no';
 
-        if ( !FieldManager::saveSettings($id, $fields) ) {
+        if (!FieldManager::saveSettings($id, $fields)) {
             return false;
         }
 
@@ -303,7 +303,7 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
         // Dynamic Options isn't an array like in Select Box Link
         $field_id = $this->get('dynamic_options');
 
-        if ( !is_null($field_id) && is_numeric($field_id) ) {
+        if (!is_null($field_id) && is_numeric($field_id)) {
             SectionManager::createSectionAssociation(null, $id, (int)$field_id, $this->get('show_association') === 'yes' ? true : false, $this->get('association_ui'), $this->get('association_editor'));
         }
 
@@ -319,39 +319,39 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
         $states = $this->getToggleStates();
         $value = isset($data['value']) ? $data['value'] : null;
 
-        if ( !is_array($value) ) {
+        if (!is_array($value)) {
             $value = array($value);
         }
 
         $options = array();
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
            # $options[] = array(null, false, null);
         }
 
-        foreach ( $states as $handle => $v ) {
+        foreach ($states as $handle => $v) {
             $options[] = array(General::sanitize($v), in_array($v, $value), General::sanitize($v));
         }
 
         $fieldname = 'fields'.$fieldnamePrefix.'['.$this->get('element_name').']'.$fieldnamePostfix;
 
-        if ( $this->get('allow_multiple_selection') === 'yes' ) {
+        if ($this->get('allow_multiple_selection') === 'yes') {
             $fieldname .= '[]';
         }
 
         $label = Widget::Label($this->get('label'));
 
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
             $label->appendChild(new XMLElement('i', __('Optional')));
         }
 
         // Create the select
         $select = new XMLElement('select', null, ['name' => $fieldname]);
 
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $select->setAttribute('required', 'required');
         }
 
-        if ( $this->get('allow_multiple_selection') === 'yes' ) {
+        if ($this->get('allow_multiple_selection') === 'yes') {
             $size = count($options) + 1;
             if ($size > 10) {
                 $size = 10;
@@ -367,7 +367,7 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
         if ($this->get('required') === 'yes') {
             $dummy->setAttribute('disabled', 'disabled');
         }
-        if ( $value[0] === null ) {
+        if ($value[0] === null) {
             $dummy->setAttribute('selected', 'selected');
         }
         $select->appendChild($dummy);
@@ -376,7 +376,7 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
         foreach ($options as $opt) {
             $option = new XMLElement('option', $opt[2]); // Display text
             $option->setAttribute('value', $opt[0]);     // Value
-            if ( $opt[1] === true ) {
+            if ($opt[1] === true) {
                 $option->setAttribute('selected', 'selected');
             }
             $select->appendChild($option);
@@ -385,7 +385,7 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
         #$select = Widget::Select($fieldname, $options, ($this->get('allow_multiple_selection') === 'yes' ? array('multiple' => 'multiple', 'size' => count($options)) : null));
         $label->appendChild($select);
 
-        if ( $flagWithError != null ) {
+        if ($flagWithError != null) {
             $wrapper->appendChild(Widget::Error($label, $flagWithError));
         } else {
             $wrapper->appendChild($label);
@@ -401,14 +401,14 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
     {
         $status = self::__OK__;
 
-        if ( !is_array($data) ) {
+        if (!is_array($data)) {
             return array(
                 'value' => $data,
                 'handle' => Lang::createHandle($data)
             );
         }
 
-        if ( empty($data) ) {
+        if (empty($data)) {
             return null;
         }
 
@@ -417,7 +417,7 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
             'handle' => array()
         );
 
-        foreach ( $data as $value ) {
+        foreach ($data as $value) {
             $result['value'][] = $value;
             $result['handle'][] = Lang::createHandle($value);
         }
@@ -445,17 +445,17 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
         $message = $status = null;
         $modes = (object)$this->getImportModes();
 
-        if ( !is_array($data) ) {
+        if (!is_array($data)) {
             $data = array($data);
         }
 
-        if ( $mode === $modes->getValue ) {
-            if ( $this->get('allow_multiple_selection') === 'no' ) {
+        if ($mode === $modes->getValue) {
+            if ($this->get('allow_multiple_selection') === 'no') {
                 $data = array(implode('', $data));
             }
 
             return $data;
-        } elseif ( $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->getPostdata) {
             return $this->processRawFieldData($data, $status, $message, true, $entry_id);
         }
 
@@ -498,32 +498,32 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
     {
         $modes = (object)$this->getExportModes();
 
-        if ( isset($data['handle']) && is_array($data['handle']) === false ) {
+        if (isset($data['handle']) && is_array($data['handle']) === false) {
             $data['handle'] = array(
                 $data['handle']
             );
         }
 
-        if ( isset($data['value']) && is_array($data['value']) === false ) {
+        if (isset($data['value']) && is_array($data['value']) === false) {
             $data['value'] = array(
                 $data['value']
             );
         }
 
         // Handle => Value pairs:
-        if ( $mode === $modes->listHandleToValue ) {
+        if ($mode === $modes->listHandleToValue) {
             return isset($data['handle'], $data['value'])
                 ? array_combine($data['handle'], $data['value'])
                 : array();
 
             // Array of handles:
-        } elseif ( $mode === $modes->listHandle ) {
+        } elseif ($mode === $modes->listHandle) {
             return isset($data['handle'])
                 ? $data['handle']
                 : array();
 
             // Array of values:
-        } elseif ( $mode === $modes->listValue || $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->listValue || $mode === $modes->getPostdata) {
             return isset($data['value'])
                 ? $data['value']
                 : array();
@@ -538,12 +538,12 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
     {
         $existing_options = $this->getToggleStates();
 
-        if ( is_array($existing_options) && !empty($existing_options) ) {
+        if (is_array($existing_options) && !empty($existing_options)) {
             $optionlist = new XMLElement('ul');
             $optionlist->setAttribute('class', 'tags');
             $optionlist->setAttribute('data-interactive', 'data-interactive');
 
-            foreach ( $existing_options as $option ) {
+            foreach ($existing_options as $option) {
                 $optionlist->appendChild(
                     new XMLElement('li', General::sanitize($option))
                 );
@@ -559,22 +559,22 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
 
     public function groupRecords($records)
     {
-        if ( !is_array($records) || empty($records) ) {
+        if (!is_array($records) || empty($records)) {
             return;
         }
 
         $groups = array($this->get('element_name') => array());
 
-        foreach ( $records as $r ) {
+        foreach ($records as $r) {
             $data = $r->getData($this->get('id'));
 
-            if ( !isset($data['value']) ) continue;
+            if (!isset($data['value'])) continue;
 
-            if ( is_array($data['value']) ) {
-                foreach ( $data['value'] as $key => $v ) {
+            if (is_array($data['value'])) {
+                foreach ($data['value'] as $key => $v) {
                     $value = General::sanitize($v);
 
-                    if ( !isset($groups[$this->get('element_name')][$data['handle'][$key]]) ) {
+                    if (!isset($groups[$this->get('element_name')][$data['handle'][$key]])) {
                         $groups[$this->get('element_name')][$data['handle'][$key]] = array(
                             'attr' => array('handle' => $data['handle'][$key], 'value' => $value),
                             'records' => array(),
@@ -588,7 +588,7 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
             else {
                 $value = General::sanitize($data['value']);
 
-                if ( !isset($groups[$this->get('element_name')][$data['handle']]) ) {
+                if (!isset($groups[$this->get('element_name')][$data['handle']])) {
                     $groups[$this->get('element_name')][$data['handle']] = array(
                         'attr' => array('handle' => $data['handle'], 'value' => $value),
                         'records' => array(),
@@ -613,32 +613,37 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
 
         $options = array();
 
-        foreach ( $states as $handle => $v ) {
+        foreach ($states as $handle => $v) {
             $options[] = array($v, null, $v);
         }
 
-        $fieldname = 'fields['.$this->get('element_name').']';
+        $fieldId = $this->get('id');
+        $fieldName = $this->get('element_name');
+        $attrName = 'fields[' . $fieldName . ']';
 
-        if ( $this->get('allow_multiple_selection') === 'yes' ) {
-            $fieldname .= '[]';
+        if ($this->get('allow_multiple_selection') === 'yes') {
+            $attrName .= '[]';
         }
 
+        $div = new XMLElement('div', null, array('class' => 'form-field'));
         $label = Widget::Label($this->get('label'));
+        $label->setAttribute('for', $fieldName . '-' . $fieldId);
         if ($this->get('required') === 'yes') {
             $mark = new XMLElement('span', '*');
-            $mark->setAttribute('aria-label', 'Required field');
+            $mark->setAttribute('aria-hidden', 'true');
             $mark->setAttribute('class', 'required-mark');
             $label->appendChild($mark);
         }
 
         // Create the select
-        $select = new XMLElement('select', null, ['name' => $fieldname]);
+        $select = new XMLElement('select', null, array('name' => $attrName));
+        $select->setAttribute('id', $fieldName . '-' . $fieldId);
 
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $select->setAttribute('required', 'required');
         }
 
-        if ( $this->get('allow_multiple_selection') === 'yes' ) {
+        if ($this->get('allow_multiple_selection') === 'yes') {
             $size = count($options) + 1;
             if ($size > 10) {
                 $size = 10;
@@ -662,15 +667,15 @@ class FieldSelect extends FieldTagList implements ExportableField, ImportableFie
         foreach ($options as $opt) {
             $option = new XMLElement('option', $opt[2]); // Display text
             $option->setAttribute('value', $opt[0]);     // Value
-            if ( $opt[1] === true ) {
+            if ($opt[1] === true) {
                 $option->setAttribute('selected', 'selected');
             }
             $select->appendChild($option);
         }
 
-        #$select = Widget::Select($fieldname, $options, ($this->get('allow_multiple_selection') === 'yes' ? array('multiple' => 'multiple', 'size' => count($options)) : null));
-        $label->appendChild($select);
+        $div->appendChild($label);
+        $div->appendChild($select);
 
-        return $label;
+        return $div;
     }
 }

--- a/symphony/lib/toolkit/fields/field.taglist.php
+++ b/symphony/lib/toolkit/fields/field.taglist.php
@@ -102,11 +102,11 @@ class FieldTagList extends Field implements ExportableField, ImportableField
 
     public function fetchAssociatedEntrySearchValue($data, $field_id = null, $parent_entry_id = null)
     {
-        if ( !is_array($data) ) {
+        if (!is_array($data)) {
             return $data;
         }
 
-        if ( !is_array($data['handle']) ) {
+        if (!is_array($data['handle'])) {
             $data['handle'] = array($data['handle']);
             $data['value'] = array($data['value']);
         }
@@ -172,7 +172,7 @@ class FieldTagList extends Field implements ExportableField, ImportableField
 
     public function set($field, $value)
     {
-        if ( $field == 'pre_populate_source' && !is_array($value) ) {
+        if ($field == 'pre_populate_source' && !is_array($value)) {
             $value = preg_split('/\s*,\s*/', $value, -1, PREG_SPLIT_NO_EMPTY);
         }
 
@@ -184,7 +184,7 @@ class FieldTagList extends Field implements ExportableField, ImportableField
      */
     public function findAllTags()
     {
-        if ( Symphony::Log() ) {
+        if (Symphony::Log()) {
             Symphony::Log()->pushDeprecateWarningToLog('FieldTagList::findAllTags()', 'FieldTagList::getToggleStates()');
         }
         $this->getToggleStates();
@@ -192,14 +192,14 @@ class FieldTagList extends Field implements ExportableField, ImportableField
 
     public function getToggleStates()
     {
-        if ( !is_array($this->get('pre_populate_source')) ) {
+        if (!is_array($this->get('pre_populate_source'))) {
             return;
         }
 
         $values = array();
 
-        foreach ( $this->get('pre_populate_source') as $item ) {
-            if ( $item === 'none' ) {
+        foreach ($this->get('pre_populate_source') as $item) {
+            if ($item === 'none') {
                 break;
             }
 
@@ -208,7 +208,7 @@ class FieldTagList extends Field implements ExportableField, ImportableField
                 ($item == 'existing' ? $this->get('id') : $item)
             ));
 
-            if ( !is_array($result) || empty($result) ) {
+            if (!is_array($result) || empty($result)) {
                 continue;
             }
 
@@ -220,7 +220,7 @@ class FieldTagList extends Field implements ExportableField, ImportableField
 
     private static function __tagArrayToString(array $tags)
     {
-        if ( empty($tags) ) {
+        if (empty($tags)) {
             return null;
         }
 
@@ -235,11 +235,11 @@ class FieldTagList extends Field implements ExportableField, ImportableField
 
     public function findDefaults(array &$settings)
     {
-        if ( !isset($settings['pre_populate_source']) ) {
+        if (!isset($settings['pre_populate_source'])) {
             $settings['pre_populate_source'] = array('existing');
         }
 
-        if ( !isset($settings['show_association']) ) {
+        if (!isset($settings['show_association'])) {
             $settings['show_association'] = 'no';
         }
     }
@@ -254,8 +254,8 @@ class FieldTagList extends Field implements ExportableField, ImportableField
         $sections = SectionManager::fetch(null, 'ASC', 'name');
         $field_groups = array();
 
-        if ( is_array($sections) && !empty($sections) ) {
-            foreach ( $sections as $section ) {
+        if (is_array($sections) && !empty($sections)) {
+            foreach ($sections as $section) {
                 $field_groups[$section->get('id')] = array('fields' => $section->fetchFields(), 'section' => $section);
             }
         }
@@ -265,20 +265,20 @@ class FieldTagList extends Field implements ExportableField, ImportableField
             array('existing', (in_array('existing', $this->get('pre_populate_source'))), __('Existing Values')),
         );
 
-        foreach ( $field_groups as $group ) {
-            if ( !is_array($group['fields']) ) {
+        foreach ($field_groups as $group) {
+            if (!is_array($group['fields'])) {
                 continue;
             }
 
             $fields = array();
 
-            foreach ( $group['fields'] as $f ) {
-                if ( $f->get('id') != $this->get('id') && $f->canPrePopulate() ) {
+            foreach ($group['fields'] as $f) {
+                if ($f->get('id') != $this->get('id') && $f->canPrePopulate()) {
                     $fields[] = array($f->get('id'), (in_array($f->get('id'), $this->get('pre_populate_source'))), $f->get('label'));
                 }
             }
 
-            if ( is_array($fields) && !empty($fields) ) {
+            if (is_array($fields) && !empty($fields)) {
                 $options[] = array('label' => $group['section']->get('name'), 'options' => $fields);
             }
         }
@@ -301,13 +301,13 @@ class FieldTagList extends Field implements ExportableField, ImportableField
 
     public function commit()
     {
-        if ( !parent::commit() ) {
+        if (!parent::commit()) {
             return false;
         }
 
         $id = $this->get('id');
 
-        if ( $id === false ) {
+        if ($id === false) {
             return false;
         }
 
@@ -316,19 +316,19 @@ class FieldTagList extends Field implements ExportableField, ImportableField
         $fields['pre_populate_source'] = (is_null($this->get('pre_populate_source')) ? 'none' : implode(',', $this->get('pre_populate_source')));
         $fields['validator'] = ($fields['validator'] == 'custom' ? null : $this->get('validator'));
 
-        if ( !FieldManager::saveSettings($id, $fields) ) {
+        if (!FieldManager::saveSettings($id, $fields)) {
             return false;
         }
 
         SectionManager::removeSectionAssociation($id);
 
-        if ( is_array($this->get('pre_populate_source')) ) {
-            foreach ( $this->get('pre_populate_source') as $field_id ) {
-                if ( $field_id === 'none' || $field_id === 'existing' ) {
+        if (is_array($this->get('pre_populate_source'))) {
+            foreach ($this->get('pre_populate_source') as $field_id) {
+                if ($field_id === 'none' || $field_id === 'existing') {
                     continue;
                 }
 
-                if ( !is_null($field_id) && is_numeric($field_id) ) {
+                if (!is_null($field_id) && is_numeric($field_id)) {
                     SectionManager::createSectionAssociation(null, $id, (int) $field_id, $this->get('show_association') === 'yes' ? true : false, $this->get('association_ui'), $this->get('association_editor'));
                 }
             }
@@ -345,38 +345,38 @@ class FieldTagList extends Field implements ExportableField, ImportableField
     {
         $value = null;
 
-        if ( isset($data['value']) ) {
+        if (isset($data['value'])) {
             $value = (is_array($data['value']) ? self::__tagArrayToString($data['value']) : $data['value']);
         }
 
         $label = Widget::Label($this->get('label'));
 
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
             $label->appendChild(new XMLElement('i', __('Optional')));
         }
 
         $input = Widget::Input('fields'.$fieldnamePrefix.'['.$this->get('element_name').']'.$fieldnamePostfix, (strlen($value) != 0 ? General::sanitize($value) : null));
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
 
         $label->appendChild($input);
 
-        if ( $flagWithError != null ) {
+        if ($flagWithError != null) {
             $wrapper->appendChild(Widget::Error($label, $flagWithError));
         } else {
             $wrapper->appendChild($label);
         }
 
-        if ( $this->get('pre_populate_source') != null ) {
+        if ($this->get('pre_populate_source') != null) {
             $existing_tags = $this->getToggleStates();
 
-            if ( is_array($existing_tags) && !empty($existing_tags) ) {
+            if (is_array($existing_tags) && !empty($existing_tags)) {
                 $taglist = new XMLElement('ul');
                 $taglist->setAttribute('class', 'tags');
                 $taglist->setAttribute('data-interactive', 'data-interactive');
 
-                foreach ( $existing_tags as $tag ) {
+                foreach ($existing_tags as $tag) {
                     $taglist->appendChild(
                         new XMLElement('li', General::sanitize($tag))
                     );
@@ -389,7 +389,7 @@ class FieldTagList extends Field implements ExportableField, ImportableField
 
     private function parseUserSubmittedData($data)
     {
-        if ( !is_array($data) ) {
+        if (!is_array($data)) {
             $data = preg_split('/\,\s*/i', $data, -1, PREG_SPLIT_NO_EMPTY);
         }
         return array_filter(array_map('trim', $data));
@@ -399,19 +399,19 @@ class FieldTagList extends Field implements ExportableField, ImportableField
     {
         $message = null;
 
-        if ( $this->get('required') === 'yes' && strlen(trim($data)) == 0 ) {
+        if ($this->get('required') === 'yes' && strlen(trim($data)) == 0) {
             $message = __('‘%s’ is a required field.', array($this->get('label')));
             return self::__MISSING_FIELDS__;
         }
 
-        if ( $this->get('validator') ) {
+        if ($this->get('validator')) {
             $data = $this->parseUserSubmittedData($data);
 
-            if ( empty($data) ) {
+            if (empty($data)) {
                 return self::__OK__;
             }
 
-            if ( !General::validateString($data, $this->get('validator')) ) {
+            if (!General::validateString($data, $this->get('validator'))) {
                 $message = __("'%s' contains invalid data. Please check the contents.", array($this->get('label')));
                 return self::__INVALID_FIELDS__;
             }
@@ -426,7 +426,7 @@ class FieldTagList extends Field implements ExportableField, ImportableField
 
         $data = $this->parseUserSubmittedData($data);
 
-        if ( empty($data) ) {
+        if (empty($data)) {
             return null;
         }
 
@@ -436,7 +436,7 @@ class FieldTagList extends Field implements ExportableField, ImportableField
         sort($data);
 
         $result = array();
-        foreach ( $data as $value ) {
+        foreach ($data as $value) {
             $result['value'][] = $value;
             $result['handle'][] = Lang::createHandle($value);
         }
@@ -450,20 +450,20 @@ class FieldTagList extends Field implements ExportableField, ImportableField
 
     public function appendFormattedElement(XMLElement &$wrapper, $data, $encode = false, $mode = null, $entry_id = null)
     {
-        if ( !is_array($data) || empty($data) || is_null($data['value']) ) {
+        if (!is_array($data) || empty($data) || is_null($data['value'])) {
             return;
         }
 
         $list = new XMLElement($this->get('element_name'));
 
-        if ( !is_array($data['handle']) && !is_array($data['value']) ) {
+        if (!is_array($data['handle']) && !is_array($data['value'])) {
             $data = array(
                 'handle'    => array($data['handle']),
                 'value'     => array($data['value'])
             );
         }
 
-        foreach ( $data['value'] as $index => $value ) {
+        foreach ($data['value'] as $index => $value) {
             $list->appendChild(new XMLElement('item', General::sanitize($value), array(
                 'handle' => $data['handle'][$index]
             )));
@@ -474,13 +474,13 @@ class FieldTagList extends Field implements ExportableField, ImportableField
 
     public function prepareTextValue($data, $entry_id = null)
     {
-        if ( !is_array($data) || empty($data) ) {
+        if (!is_array($data) || empty($data)) {
             return '';
         }
 
         $value = '';
 
-        if ( isset($data['value']) ) {
+        if (isset($data['value'])) {
             $value = (is_array($data['value']) ? self::__tagArrayToString($data['value']) : $data['value']);
         }
 
@@ -494,45 +494,50 @@ class FieldTagList extends Field implements ExportableField, ImportableField
 
     public function getExampleFormMarkup()
     {
-        $wrapper = new XMLElement('div');
+        $fieldId = $this->get('id');
+        $fieldName = $this->get('element_name');
 
+        $div = new XMLElement('div', null, array('class' => 'form-field'));
         $label = new XMLElement('label', $this->get('label'));
+        $label->setAttribute('for', $fieldName . '-' . $fieldId);
         if ($this->get('required') === 'yes') {
             $mark = new XMLElement('span', '*');
-            $mark->setAttribute('aria-label', 'Required field');
+            $mark->setAttribute('aria-hidden', 'true');
             $mark->setAttribute('class', 'required-mark');
             $label->appendChild($mark);
         }
 
         $input = Widget::Input('fields['.$this->get('element_name').']', null, 'text');
-        if ( $this->get('required') === 'yes' ) {
+        $input->setAttribute('id', $fieldName . '-' . $fieldId);
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
 
-        $label->appendChild($input);
-        $wrapper->appendChild($label);
-        if ( $this->get('pre_populate_source') != null ) {
+        $div->appendChild($label);
+        $div->appendChild($input);
+
+        if ($this->get('pre_populate_source') != null) {
             $existing_tags = $this->getToggleStates();
 
-            if ( is_array($existing_tags) && !empty($existing_tags) ) {
+            if (is_array($existing_tags) && !empty($existing_tags)) {
                 $taglist = new XMLElement('ul');
                 $taglist->setAttribute('class', 'tags');
                 $taglist->setAttribute('data-interactive', 'data-interactive');
 
-                $notice = "\n<!-- Please note: The values are a static example. To obtain the values dynamically, use a data source and access it in your template. -->";
+                $notice = __("\n<!-- Please note: The values are a static example. To obtain the values dynamically, use a data source and access it in your template. -->");
                 $taglist->setValue($notice);
 
-                foreach ( $existing_tags as $tag ) {
+                foreach ($existing_tags as $tag) {
                     $taglist->appendChild(
                         new XMLElement('li', General::sanitize($tag))
                     );
                 }
 
-                $wrapper->appendChild($taglist);
+                $div->appendChild($taglist);
             }
         }
 
-        return $wrapper;
+        return $div;
     }
 
     /*-------------------------------------------------------------------------
@@ -552,13 +557,13 @@ class FieldTagList extends Field implements ExportableField, ImportableField
         $message = $status = null;
         $modes = (object)$this->getImportModes();
 
-        if ( is_array($data) ) {
+        if (is_array($data)) {
             $data = implode(', ', $data);
         }
 
-        if ( $mode === $modes->getValue ) {
+        if ($mode === $modes->getValue) {
             return $data;
-        } elseif ( $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->getPostdata) {
             return $this->processRawFieldData($data, $status, $message, true, $entry_id);
         }
 
@@ -601,38 +606,38 @@ class FieldTagList extends Field implements ExportableField, ImportableField
     {
         $modes = (object)$this->getExportModes();
 
-        if ( isset($data['handle']) && is_array($data['handle']) === false ) {
+        if (isset($data['handle']) && is_array($data['handle']) === false) {
             $data['handle'] = array(
                 $data['handle']
             );
         }
 
-        if ( isset($data['value']) && is_array($data['value']) === false ) {
+        if (isset($data['value']) && is_array($data['value']) === false) {
             $data['value'] = array(
                 $data['value']
             );
         }
 
         // Handle => value pairs:
-        if ( $mode === $modes->listHandleToValue ) {
+        if ($mode === $modes->listHandleToValue) {
             return isset($data['handle'], $data['value'])
                 ? array_combine($data['handle'], $data['value'])
                 : array();
 
             // Array of handles:
-        } elseif ( $mode === $modes->listHandle ) {
+        } elseif ($mode === $modes->listHandle) {
             return isset($data['handle'])
                 ? $data['handle']
                 : array();
 
             // Array of values:
-        } elseif ( $mode === $modes->listValue ) {
+        } elseif ($mode === $modes->listValue) {
             return isset($data['value'])
                 ? $data['value']
                 : array();
 
             // Comma seperated values:
-        } elseif ( $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->getPostdata) {
             return isset($data['value'])
                 ? implode(', ', $data['value'])
                 : null;
@@ -645,15 +650,15 @@ class FieldTagList extends Field implements ExportableField, ImportableField
 
     public function displayFilteringOptions(XMLElement &$wrapper)
     {
-        if ( $this->get('pre_populate_source') != null ) {
+        if ($this->get('pre_populate_source') != null) {
             $existing_tags = $this->getToggleStates();
 
-            if ( is_array($existing_tags) && !empty($existing_tags) ) {
+            if (is_array($existing_tags) && !empty($existing_tags)) {
                 $taglist = new XMLElement('ul');
                 $taglist->setAttribute('class', 'tags');
                 $taglist->setAttribute('data-interactive', 'data-interactive');
 
-                foreach ( $existing_tags as $tag ) {
+                foreach ($existing_tags as $tag) {
                     $taglist->appendChild(
                         new XMLElement('li', General::sanitize($tag))
                     );
@@ -709,36 +714,36 @@ class FieldTagList extends Field implements ExportableField, ImportableField
     {
         $field_id = $this->get('id');
 
-        if ( self::isFilterRegex($data[0]) ) {
+        if (self::isFilterRegex($data[0])) {
             $this->buildRegexSQL($data[0], array('value', 'handle'), $joins, $where);
-        } elseif ( self::isFilterSQL($data[0]) ) {
+        } elseif (self::isFilterSQL($data[0])) {
             $this->buildFilterSQL($data[0], array('value', 'handle'), $joins, $where);
         } else {
             $negation = false;
             $null = false;
-            if ( preg_match('/^not:/', $data[0]) ) {
+            if (preg_match('/^not:/', $data[0])) {
                 $data[0] = preg_replace('/^not:/', null, $data[0]);
                 $negation = true;
-            } elseif ( preg_match('/^sql-null-or-not:/', $data[0]) ) {
+            } elseif (preg_match('/^sql-null-or-not:/', $data[0])) {
                 $data[0] = preg_replace('/^sql-null-or-not:/', null, $data[0]);
                 $negation = true;
                 $null = true;
             }
 
-            foreach ( $data as &$value ) {
+            foreach ($data as &$value) {
                 $value = $this->cleanValue($value);
             }
 
-            if ( $andOperation ) {
+            if ($andOperation) {
                 $condition = ($negation) ? '!=' : '=';
-                foreach ( $data as $key => $bit ) {
+                foreach ($data as $key => $bit) {
                     $joins .= " LEFT JOIN `tbl_entries_data_$field_id` AS `t{$field_id}_{$this->_key}` ON (`e`.`id` = `t{$field_id}_{$this->_key}`.entry_id) ";
                     $where .= " AND ((
                                         t{$field_id}_{$this->_key}.value $condition '$bit'
                                         OR t{$field_id}_{$this->_key}.handle $condition '$bit'
                                     )";
 
-                    if ( $null ) {
+                    if ($null) {
                         $where .= " OR `t{$field_id}_{$this->_key}`.`value` IS NULL) ";
                     } else {
                         $where .= ") ";
@@ -749,7 +754,7 @@ class FieldTagList extends Field implements ExportableField, ImportableField
                 $data = "'".implode("', '", $data)."'";
 
                 // Apply a different where condition if we are using $negation. RE: #29
-                if ( $negation ) {
+                if ($negation) {
                     $condition = 'NOT EXISTS';
                     $where .= " AND $condition (
                         SELECT *

--- a/symphony/lib/toolkit/fields/field.tel.php
+++ b/symphony/lib/toolkit/fields/field.tel.php
@@ -150,7 +150,7 @@ class FieldTel extends Field
 
     public function commit()
     {
-        if ( !parent::commit() ) return false;
+        if (!parent::commit()) return false;
 
         return FieldManager::saveSettings($this->get('id'), [
             'minlength' => $this->get('minlength'),
@@ -169,29 +169,29 @@ class FieldTel extends Field
         $value = isset($data['value']) ? $data['value'] : null;
 
         $input = Widget::input("fields{$fieldnamePrefix}[{$this->get('element_name')}]{$fieldnamePostfix}", $value, 'tel');
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
-        if ( $this->get('minlength') !== null ) {
+        if ($this->get('minlength') !== null) {
             $input->setAttribute('minlength', $this->get('minlength'));
         }
-        if ( $this->get('maxlength') !== null ) {
+        if ($this->get('maxlength') !== null) {
             $input->setAttribute('maxlength', $this->get('maxlength'));
         }
-        if ( $this->get('placeholder') !== null ) {
+        if ($this->get('placeholder') !== null) {
             $input->setAttribute('placeholder', $this->get('placeholder'));
         }
-        if ( $this->get('pattern') !== null ) {
+        if ($this->get('pattern') !== null) {
             $input->setAttribute('pattern', $this->get('pattern'));
         }
 
         $label = Widget::label($this->get('label'));
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
             $label->appendChild(new XMLElement('i', __('Optional')));
         }
         $label->appendChild($input);
 
-        if ( $flagWithError != null ) {
+        if ($flagWithError != null) {
             $wrapper->appendChild(Widget::Error($label, $flagWithError));
         } else {
             $wrapper->appendChild($label);
@@ -205,19 +205,19 @@ class FieldTel extends Field
         $element = new XMLElement($this->get('element_name'), $value);
 
         // Return additional attributes 'minlength', 'maxlength' 'placeholder' and 'pattern'
-        if ( $this->get('minlength') !== null ) {
+        if ($this->get('minlength') !== null) {
             $element->setAttribute('minlength', $this->get('minlength'));
         }
 
-        if ( $this->get('maxlength') !== null ) {
+        if ($this->get('maxlength') !== null) {
             $element->setAttribute('maxlength', $this->get('maxlength'));
         }
 
-        if ( $this->get('placeholder') !== null ) {
+        if ($this->get('placeholder') !== null) {
             $element->setAttribute('placeholder', $this->get('placeholder'));
         }
 
-        if ( $this->get('pattern') !== null ) {
+        if ($this->get('pattern') !== null) {
             $element->setAttribute('pattern', $this->get('pattern'));
         }
 
@@ -226,46 +226,54 @@ class FieldTel extends Field
 
     public function getExampleFormMarkup()
     {
+        $fieldId = $this->get('id');
+        $fieldName = $this->get('element_name');
+
         $hint = '';
-        if ( $this->get('pattern') !== null ) {
-            $hint = "\n" . '<!-- Note: The double curly brackets in the attribute `pattern` are not an error but necessary because XSLT interprets `{...}` as an expression -->';
+        if ($this->get('pattern') !== null) {
+            $hint = "\n" . __('<!-- Note: The double curly brackets in the attribute `pattern` are not an error but necessary because XSLT interprets `{...}` as an expression -->');
         }
 
-        $label = new XMLElement('label', $this->get('label')  . $hint);
+        $div = new XMLElement('div', $hint, array('class' => 'form-field'));
+
+        $label = Widget::Label($this->get('label'));
+        $label->setAttribute('for', $fieldName . '-' . $fieldId);
         if ($this->get('required') === 'yes') {
             $mark = new XMLElement('span', '*');
-            $mark->setAttribute('aria-label', 'Required field');
+            $mark->setAttribute('aria-hidden', 'true');
             $mark->setAttribute('class', 'required-mark');
             $label->appendChild($mark);
         }
 
         $input = Widget::input('fields['.$this->get('element_name').']', null, 'tel');
+        $input->setAttribute('id', $fieldName . '-' . $fieldId);
 
         // Return additional attributes 'minlength', 'maxlength' 'placeholder' and 'pattern'
-        if ( $this->get('minlength') !== null ) {
+        if ($this->get('minlength') !== null) {
             $input->setAttribute('minlength', $this->get('minlength'));
         }
 
-        if ( $this->get('maxlength') !== null ) {
+        if ($this->get('maxlength') !== null) {
             $input->setAttribute('maxlength', $this->get('maxlength'));
         }
 
-        if ( $this->get('placeholder') !== null ) {
+        if ($this->get('placeholder') !== null) {
             $input->setAttribute('placeholder', $this->get('placeholder'));
         }
 
-        if ( $this->get('pattern') !== null ) {
+        if ($this->get('pattern') !== null) {
             $input->setAttribute('pattern', str_replace( array( '{', '}' ), array( '{{', '}}' ), $this->get('pattern')));
             $input->setAttribute('inputmode', 'tel');
         }
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
         $input->setAttribute('autocomplete', 'tel');
 
-        $label->appendChild($input);
+        $div->appendChild($label);
+        $div->appendChild($input);
 
-        return $label;
+        return $div;
     }
 
     public function checkPostFieldData($data, &$message, $entry_id = null)
@@ -286,7 +294,7 @@ class FieldTel extends Field
         $message = null;
 
 
-        if ( $this->get('required') === 'yes' && strlen(trim($data)) === 0 ) {
+        if ($this->get('required') === 'yes' && strlen(trim($data)) === 0) {
             $message = $messages['required'];
             return self::__MISSING_FIELDS__;
         }
@@ -333,7 +341,7 @@ class FieldTel extends Field
     {
         $status = self::__OK__;
 
-        if ( strlen(trim($data)) == 0 ) return array();
+        if (strlen(trim($data)) == 0) return array();
 
         $result = array(
             'value' => $data
@@ -359,9 +367,9 @@ class FieldTel extends Field
         $message = $status = null;
         $modes = (object)$this->getImportModes();
 
-        if ( $mode === $modes->getValue ) {
+        if ($mode === $modes->getValue) {
             return $data;
-        } else if ( $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->getPostdata) {
             return $this->processRawFieldData($data, $status, $message, true, $entry_id);
         }
 
@@ -399,7 +407,7 @@ class FieldTel extends Field
         $modes = (object)$this->getExportModes();
 
         // Export unformatted:
-        if ( $mode === $modes->getUnformatted || $mode === $modes->getPostdata ) {
+        if ($mode === $modes->getUnformatted || $mode === $modes->getPostdata) {
             return isset($data['value'])
                 ? $data['value']
                 : null;
@@ -414,16 +422,16 @@ class FieldTel extends Field
 
     public function groupRecords($records)
     {
-        if ( !is_array($records) || empty($records) ) return;
+        if (!is_array($records) || empty($records)) return;
 
         $groups = array($this->get('element_name') => array());
 
-        foreach ( $records as $r ) {
+        foreach ($records as $r) {
             $data = $r->getData($this->get('id'));
 
             $value = $data['value'];
 
-            if ( !isset($groups[$this->get('element_name')][$value]) ) {
+            if (!isset($groups[$this->get('element_name')][$value])) {
                 $groups[$this->get('element_name')][$value] = array(
                     'attr' => array('value' => $value),
                     'records' => array(),

--- a/symphony/lib/toolkit/fields/field.textarea.php
+++ b/symphony/lib/toolkit/fields/field.textarea.php
@@ -60,17 +60,17 @@ class fieldTextarea extends Field implements ExportableField, ImportableField
     {
         $result = '';
 
-        if ( $this->get('formatter') ) {
+        if ($this->get('formatter')) {
             $formatter = TextformatterManager::create($this->get('formatter'));
             $result = $formatter->run($data);
         }
 
-        if ( $validate === true ) {
-            if ( !General::validateXML($result, $errors, false, new XsltProcess) ) {
+        if ($validate === true) {
+            if (!General::validateXML($result, $errors, false, new XsltProcess)) {
                 $result = html_entity_decode($result, ENT_QUOTES, 'UTF-8');
                 $result = $this->__replaceAmpersands($result);
 
-                if ( !General::validateXML($result, $errors, false, new XsltProcess) ) {
+                if (!General::validateXML($result, $errors, false, new XsltProcess)) {
                     return false;
                 }
             }
@@ -90,7 +90,7 @@ class fieldTextarea extends Field implements ExportableField, ImportableField
 
     public function findDefaults(array &$settings)
     {
-        if ( !isset($settings['size']) ) {
+        if (!isset($settings['size'])) {
             $settings['size'] = 15;
         }
     }
@@ -116,19 +116,19 @@ class fieldTextarea extends Field implements ExportableField, ImportableField
 
     public function commit()
     {
-        if ( !parent::commit() ) {
+        if (!parent::commit()) {
             return false;
         }
 
         $id = $this->get('id');
 
-        if ( $id === false ) {
+        if ($id === false) {
             return false;
         }
 
         $fields = array();
 
-        if ( $this->get('formatter') != 'none' ) {
+        if ($this->get('formatter') != 'none') {
             $fields['formatter'] = $this->get('formatter');
         }
 
@@ -145,17 +145,17 @@ class fieldTextarea extends Field implements ExportableField, ImportableField
     {
         $label = Widget::Label($this->get('label'));
 
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
             $label->appendChild(new XMLElement('i', __('Optional')));
         }
 
         $value = isset($data['value']) ? $data['value'] : null;
         $textarea = Widget::Textarea('fields'.$fieldnamePrefix.'['.$this->get('element_name').']'.$fieldnamePostfix, (int)$this->get('size'), 50, (strlen($value) != 0 ? General::sanitizeDouble($value) : null));
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $textarea->setAttribute('required', 'required');
         }
 
-        if ( $this->get('formatter') != 'none' ) {
+        if ($this->get('formatter') != 'none') {
             $textarea->setAttribute('class', $this->get('formatter'));
         }
 
@@ -177,7 +177,7 @@ class fieldTextarea extends Field implements ExportableField, ImportableField
 
         $label->appendChild($textarea);
 
-        if ( $flagWithError != null ) {
+        if ($flagWithError != null) {
             $wrapper->appendChild(Widget::Error($label, $flagWithError));
         } else {
             $wrapper->appendChild($label);
@@ -188,12 +188,12 @@ class fieldTextarea extends Field implements ExportableField, ImportableField
     {
         $message = null;
 
-        if ( $this->get('required') === 'yes' && strlen(trim($data)) == 0 ) {
+        if ($this->get('required') === 'yes' && strlen(trim($data)) == 0) {
             $message = __('‘%s’ is a required field.', array($this->get('label')));
             return self::__MISSING_FIELDS__;
         }
 
-        if ( $this->__applyFormatting($data, true, $errors) === false ) {
+        if ($this->__applyFormatting($data, true, $errors) === false) {
             $message = __('‘%s’ contains invalid XML.', array($this->get('label'))) . ' ' . __('The following error was returned:') . ' <code>' . $errors[0]['message'] . '</code>';
             return self::__INVALID_FIELDS__;
         }
@@ -205,7 +205,7 @@ class fieldTextarea extends Field implements ExportableField, ImportableField
     {
         $status = self::__OK__;
 
-        if ( strlen(trim($data)) == 0 ) {
+        if (strlen(trim($data)) == 0) {
             return array();
         }
 
@@ -215,7 +215,7 @@ class fieldTextarea extends Field implements ExportableField, ImportableField
 
         $result['value_formatted'] = $this->__applyFormatting($data, true, $errors);
 
-        if ( $result['value_formatted'] === false ) {
+        if ($result['value_formatted'] === false) {
             // Run the formatter again, but this time do not validate. We will sanitize the output
             $result['value_formatted'] = General::sanitize($this->__applyFormatting($data));
         }
@@ -229,7 +229,7 @@ class fieldTextarea extends Field implements ExportableField, ImportableField
 
     public function fetchIncludableElements()
     {
-        if ( $this->get('formatter') ) {
+        if ($this->get('formatter')) {
             return array(
                 $this->get('element_name') . ': formatted',
                 $this->get('element_name') . ': unformatted'
@@ -245,11 +245,11 @@ class fieldTextarea extends Field implements ExportableField, ImportableField
     {
         $attributes = array();
 
-        if ( !is_null($mode) ) {
+        if (!is_null($mode)) {
             $attributes['mode'] = $mode;
         }
 
-        if ( $mode == 'formatted' ) {
+        if ($mode == 'formatted') {
             if ($this->get('formatter') && isset($data['value_formatted'])) {
                 $value = $data['value_formatted'];
             } else {
@@ -263,7 +263,7 @@ class fieldTextarea extends Field implements ExportableField, ImportableField
                     $attributes
                 )
             );
-        } elseif ( $mode == null || $mode == 'unformatted' ) {
+        } elseif ($mode == null || $mode == 'unformatted') {
             $data['value'] = $data['value'] ?? null;
             $value = !empty($data['value'])
                 ? sprintf('<![CDATA[%s]]>', str_replace(']]>', ']]]]><![CDATA[>', $data['value']))
@@ -292,9 +292,9 @@ class fieldTextarea extends Field implements ExportableField, ImportableField
         $message = $status = null;
         $modes = (object)$this->getImportModes();
 
-        if ( $mode === $modes->getValue ) {
+        if ($mode === $modes->getValue) {
             return $data;
-        } elseif ( $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->getPostdata) {
             return $this->processRawFieldData($data, $status, $message, true, $entry_id);
         }
 
@@ -334,24 +334,24 @@ class fieldTextarea extends Field implements ExportableField, ImportableField
         $modes = (object)$this->getExportModes();
 
         // Export handles:
-        if ( $mode === $modes->getHandle ) {
-            if ( isset($data['handle']) ) {
+        if ($mode === $modes->getHandle) {
+            if (isset($data['handle'])) {
                 return $data['handle'];
-            } elseif ( isset($data['value']) ) {
+            } elseif (isset($data['value'])) {
                 return Lang::createHandle($data['value']);
             }
 
             // Export unformatted:
-        } elseif ( $mode === $modes->getUnformatted || $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->getUnformatted || $mode === $modes->getPostdata) {
             return isset($data['value'])
                 ? $data['value']
                 : null;
 
             // Export formatted:
-        } elseif ( $mode === $modes->getFormatted ) {
-            if ( isset($data['value_formatted']) ) {
+        } elseif ($mode === $modes->getFormatted) {
+            if (isset($data['value_formatted'])) {
                 return $data['value_formatted'];
-            } elseif ( isset($data['value']) ) {
+            } elseif (isset($data['value'])) {
                 return General::sanitize($data['value']);
             }
         }
@@ -367,9 +367,9 @@ class fieldTextarea extends Field implements ExportableField, ImportableField
     {
         $field_id = $this->get('id');
 
-        if ( self::isFilterRegex($data[0]) ) {
+        if (self::isFilterRegex($data[0])) {
             $this->buildRegexSQL($data[0], array('value'), $joins, $where);
-        } elseif ( self::isFilterSQL($data[0]) ) {
+        } elseif (self::isFilterSQL($data[0])) {
             $this->buildFilterSQL($data[0], array('value'), $joins, $where);
         } else {
             if (is_array($data)) {
@@ -397,20 +397,27 @@ class fieldTextarea extends Field implements ExportableField, ImportableField
 
     public function getExampleFormMarkup()
     {
+        $fieldId = $this->get('id');
+        $fieldName = $this->get('element_name');
+
+        $div = new XMLElement('div', null, array('class' => 'form-field'));
         $label = Widget::Label($this->get('label'));
-        if ( $this->get('required') === 'yes' ) {
+        $label->setAttribute('for', $fieldName . '-' . $fieldId);
+        if ($this->get('required') === 'yes') {
             $mark = new XMLElement('span', '*');
-            $mark->setAttribute('aria-label', 'Required field');
+            $mark->setAttribute('aria-hidden', 'true');
             $mark->setAttribute('class', 'required-mark');
             $label->appendChild($mark);
         }
-        $textarea = Widget::Textarea('fields['.$this->get('element_name').']', (int)$this->get('size'), 50);
-        if ( $this->get('required') === 'yes' ) {
+        $textarea = Widget::Textarea('fields[' . $fieldName . ']', (int)$this->get('size'), 50);
+        $textarea->setAttribute('id', $fieldName . '-' . $fieldId);
+        if ($this->get('required') === 'yes') {
             $textarea->setAttribute('required', 'required');
         }
 
-        $label->appendChild($textarea);
+        $div->appendChild($label);
+        $div->appendChild($textarea);
 
-        return $label;
+        return $div;
     }
 }

--- a/symphony/lib/toolkit/fields/field.time.php
+++ b/symphony/lib/toolkit/fields/field.time.php
@@ -108,7 +108,7 @@ class FieldTime extends Field
         $default = new XMLElement('label', __('Set current time as value'));
         $default->setAttribute('class', 'column');
         $input = Widget::Input('fields['.$this->get('sortorder').'][default_time]', 'on', 'checkbox');
-        if ( $this->get('default_time') === 'on' ) {
+        if ($this->get('default_time') === 'on') {
             $input->setAttribute('checked', 'checked');
         }
         $default->appendChild($input);
@@ -180,7 +180,7 @@ class FieldTime extends Field
 
     public function commit()
     {
-        if ( !parent::commit() ) return false;
+        if (!parent::commit()) return false;
 
         return FieldManager::saveSettings($this->get('id'), [
             'default_time' => $this->get('default_time') === 'on' ? 'on' : 'off',
@@ -200,36 +200,36 @@ class FieldTime extends Field
         $value = isset($data['value']) ? $data['value'] : null;
 
         $input = Widget::input("fields{$fieldnamePrefix}[{$this->get('element_name')}]{$fieldnamePostfix}", $value, 'time');
-        if ( $value === null and $this->get('default_time') === 'on' ) {
+        if ($value === null and $this->get('default_time') === 'on') {
             $input->setAttribute('value', date('H:i'));
         }
-        else if ( $value === null and $this->get('custom_time') !== null ) {
+        elseif ($value === null and $this->get('custom_time') !== null) {
             $input->setAttribute('value', $this->get('custom_time'));
         }
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
 
         // Return additional attributes 'min', 'max' and 'step'
-        if ( $this->get('min') !== null ) {
+        if ($this->get('min') !== null) {
             $input->setAttribute('min', $this->get('min'));
         }
 
-        if ( $this->get('max') !== null ) {
+        if ($this->get('max') !== null) {
             $input->setAttribute('max', $this->get('max'));
         }
 
-        if ( $this->get('step') !== '60' ){
+        if ($this->get('step') !== '60'){
             $input->setAttribute('step', $this->get('step'));
         }
 
         $label = Widget::label($this->get('label'));
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
             $label->appendChild(new XMLElement('i', __('Optional')));
         }
         $label->appendChild($input);
 
-        if ( $flagWithError != null ) {
+        if ($flagWithError != null) {
             $wrapper->appendChild(Widget::Error($label, $flagWithError));
         } else {
             $wrapper->appendChild($label);
@@ -243,15 +243,15 @@ class FieldTime extends Field
         $element = new XMLElement($this->get('element_name'), $value);
 
         // Return additional attributes 'min', 'max' and 'step'
-        if ( $this->get('min') !== null ) {
+        if ($this->get('min') !== null) {
             $element->setAttribute('min', $this->get('min'));
         }
 
-        if ( $this->get('max') !== null ) {
+        if ($this->get('max') !== null) {
             $element->setAttribute('max', $this->get('max'));
         }
 
-        if ( $this->get('step') !== null ) {
+        if ($this->get('step') !== null) {
             $element->setAttribute('step', $this->get('step'));
         }
 
@@ -260,38 +260,44 @@ class FieldTime extends Field
 
     public function getExampleFormMarkup()
     {
-        $label = new XMLElement('label', $this->get('label'));
+        $fieldId = $this->get('id');
+        $fieldName = $this->get('element_name');
 
+        $div = new XMLElement('div', null, array('class' => 'form-field'));
+        $label = Widget::Label($this->get('label'));
+        $label->setAttribute('for', $fieldName . '-' . $fieldId);
         if ($this->get('required') === 'yes') {
             $mark = new XMLElement('span', '*');
-            $mark->setAttribute('aria-label', 'Required field');
+            $mark->setAttribute('aria-hidden', 'true');
             $mark->setAttribute('class', 'required-mark');
             $label->appendChild($mark);
         }
 
-        $input = Widget::input('fields['.$this->get('element_name').']', null, 'time');
-        if ( $this->get('custom_time') !== null ) {
+        $input = Widget::input('fields[' . $fieldName . ']', null, 'time');
+        $input->setAttribute('id', $fieldName . '-' . $fieldId);
+        if ($this->get('custom_time') !== null) {
             $input->setAttribute('value', $this->get('custom_time'));
         }
-        if ( $this->get('default_time') === 'on' ) {
+        if ($this->get('default_time') === 'on') {
             $input->setAttribute('value', '{/data/params/current-time}');
         }
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
-        if ( $this->get('step') !== '60' ) {
+        if ($this->get('step') !== '60') {
             $input->setAttribute('step', $this->get('step'));
         }
-        if ( $this->get('min') !== null ) {
+        if ($this->get('min') !== null) {
             $input->setAttribute('min', $this->get('min'));
         }
-        if ( $this->get('max') !== null ) {
+        if ($this->get('max') !== null) {
             $input->setAttribute('max', $this->get('max'));
         }
 
-        $label->appendChild($input);
+        $div->appendChild($label);
+        $div->appendChild($input);
 
-        return $label;
+        return $div;
     }
 
     public function checkPostFieldData($data, &$message, $entry_id = null)
@@ -312,12 +318,12 @@ class FieldTime extends Field
         );
         $message = null;
 
-        if ( $this->get('required') === 'yes' && strlen($data) === 0 ) {
+        if ($this->get('required') === 'yes' && strlen($data) === 0) {
             $message =$messages['required'];
             return self::__MISSING_FIELDS__;
         }
 
-        if ( strlen($data) > 0 && !preg_match('/^(\d{2}):(\d{2})(?::(\d{2}))?$/', $data) ) {
+        if (strlen($data) > 0 && !preg_match('/^(\d{2}):(\d{2})(?::(\d{2}))?$/', $data)) {
             $message = $messages['invalid'];
             return self::__INVALID_FIELDS__;
         }
@@ -327,27 +333,27 @@ class FieldTime extends Field
             $minute = (int)$matches[2];
             $second = isset($matches[3]) ? (int)$matches[3] : 0;
 
-            if ( $hour >= 24 ) {
+            if ($hour >= 24) {
                 $message = $messages['hours'];
                 return self::__INVALID_FIELDS__;
             }
-            elseif ( $minute >= 60 ) {
+            elseif ($minute >= 60) {
                 $message = $messages['minutes'];
                 return self::__INVALID_FIELDS__;
             }
-            elseif ( $second >= 60) {
+            elseif ($second >= 60) {
                 $message = $messages['seconds'];
                 return self::__INVALID_FIELDS__;
             }
         }
 
-        if ( preg_match('/^(\d{2}):(\d{2})(?::(\d{2}))?$/', $data) ) {
-            if ( $min !== null && $data < $min ) {
+        if (preg_match('/^(\d{2}):(\d{2})(?::(\d{2}))?$/', $data)) {
+            if ($min !== null && $data < $min) {
                 $message = $messages['min'];
                 return self::__INVALID_FIELDS__;
             }
 
-            if ( $max !== null && $data > $max ) {
+            if ($max !== null && $data > $max) {
                 $message = $messages['max'];
                 return self::__INVALID_FIELDS__;
             }
@@ -371,7 +377,7 @@ class FieldTime extends Field
     {
         $status = self::__OK__;
 
-        if ( strlen(trim($data)) == 0 ) return array();
+        if (strlen(trim($data)) == 0) return array();
 
         $result = array(
             'value' => $data
@@ -398,9 +404,9 @@ class FieldTime extends Field
         $message = $status = null;
         $modes = (object)$this->getImportModes();
 
-        if ( $mode === $modes->getValue ) {
+        if ($mode === $modes->getValue) {
             return $data;
-        } else if ( $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->getPostdata) {
             return $this->processRawFieldData($data, $status, $message, true, $entry_id);
         }
 
@@ -438,7 +444,7 @@ class FieldTime extends Field
         $modes = (object)$this->getExportModes();
 
         // Export unformatted:
-        if ( $mode === $modes->getUnformatted || $mode === $modes->getPostdata ) {
+        if ($mode === $modes->getUnformatted || $mode === $modes->getPostdata) {
             return isset($data['value'])
                 ? $data['value']
                 : null;
@@ -530,16 +536,16 @@ class FieldTime extends Field
 
     public function groupRecords($records)
     {
-        if ( !is_array($records) || empty($records) ) return;
+        if (!is_array($records) || empty($records)) return;
 
         $groups = array($this->get('element_name') => array());
 
-        foreach ( $records as $r ) {
+        foreach ($records as $r) {
             $data = $r->getData($this->get('id'));
 
             $value = $data['value'];
 
-            if ( !isset($groups[$this->get('element_name')][$value]) ) {
+            if (!isset($groups[$this->get('element_name')][$value])) {
                 $groups[$this->get('element_name')][$value] = array(
                     'attr' => array('value' => $value),
                     'records' => array(),

--- a/symphony/lib/toolkit/fields/field.upload.php
+++ b/symphony/lib/toolkit/fields/field.upload.php
@@ -121,7 +121,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
     {
         $file_location = $this->getFilePath($data['file']);
 
-        if ( is_file($file_location) ) {
+        if (is_file($file_location)) {
             General::deleteFile($file_location);
         }
 
@@ -134,13 +134,13 @@ class FieldUpload extends Field implements ExportableField, ImportableField
     {
         $meta = array();
 
-        if ( !file_exists($file) || !is_readable($file) ) {
+        if (!file_exists($file) || !is_readable($file)) {
             return $meta;
         }
 
         $meta['creation'] = DateTimeObj::get('c', filemtime($file));
 
-        if ( General::in_iarray($type, fieldUpload::$imageMimeTypes) && $array = @getimagesize($file) ) {
+        if (General::in_iarray($type, fieldUpload::$imageMimeTypes) && $array = @getimagesize($file)) {
             $meta['width'] = $array[0];
             $meta['height'] = $array[1];
         }
@@ -182,8 +182,8 @@ class FieldUpload extends Field implements ExportableField, ImportableField
         $options = array();
         $options[] = array('/workspace', false, '/workspace');
 
-        if ( !empty($directories) && is_array($directories) ) {
-            foreach ( $directories as $d ) {
+        if (!empty($directories) && is_array($directories)) {
+            foreach ($directories as $d) {
                 $d = '/' . trim($d, '/');
 
                 if (!in_array($d, $ignore)) {
@@ -194,7 +194,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
 
         $label->appendChild(Widget::Select('fields['.$this->get('sortorder').'][destination]', $options));
 
-        if ( isset($errors['destination']) ) {
+        if (isset($errors['destination'])) {
             $wrapper->appendChild(Widget::Error($label, $errors['destination']));
         } else {
             $wrapper->appendChild($label);
@@ -209,11 +209,11 @@ class FieldUpload extends Field implements ExportableField, ImportableField
 
     public function checkFields(array &$errors, $checkForDuplicates = true)
     {
-        if ( is_dir(DOCROOT . $this->get('destination') . '/') === false ) {
+        if (is_dir(DOCROOT . $this->get('destination') . '/') === false) {
             $errors['destination'] = __('The destination directory, %s, does not exist.', array(
                 '<code>' . $this->get('destination') . '</code>'
             ));
-        } elseif ( is_writable(DOCROOT . $this->get('destination') . '/') === false ) {
+        } elseif (is_writable(DOCROOT . $this->get('destination') . '/') === false) {
             $errors['destination'] = __('The destination directory is not writable.')
                 . ' '
                 . __('Please check permissions on %s.', array(
@@ -226,13 +226,13 @@ class FieldUpload extends Field implements ExportableField, ImportableField
 
     public function commit()
     {
-        if ( !parent::commit() ) {
+        if (!parent::commit()) {
             return false;
         }
 
         $id = $this->get('id');
 
-        if ( $id === false ) {
+        if ($id === false) {
             return false;
         }
 
@@ -253,11 +253,11 @@ class FieldUpload extends Field implements ExportableField, ImportableField
 
     public function displayPublishPanel(XMLElement &$wrapper, $data = null, $flagWithError = null, $fieldnamePrefix = null, $fieldnamePostfix = null, $entry_id = null)
     {
-        if ( is_dir(DOCROOT . $this->get('destination') . '/') === false ) {
+        if (is_dir(DOCROOT . $this->get('destination') . '/') === false) {
             $flagWithError = __('The destination directory, %s, does not exist.', array(
                 '<code>' . $this->get('destination') . '</code>'
             ));
-        } elseif ( $flagWithError && is_writable(DOCROOT . $this->get('destination') . '/') === false ) {
+        } elseif ($flagWithError && is_writable(DOCROOT . $this->get('destination') . '/') === false) {
             $flagWithError = __('Destination folder is not writable.')
                 . ' '
                 . __('Please check permissions on %s.', array(
@@ -268,16 +268,16 @@ class FieldUpload extends Field implements ExportableField, ImportableField
         $label = Widget::Label($this->get('label'));
         $label->setAttribute('class', 'file');
 
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
             $label->appendChild(new XMLElement('i', __('Optional')));
         }
 
         $span = new XMLElement('span', null, array('class' => 'frame'));
 
-        if ( isset($data['file']) ) {
+        if (isset($data['file'])) {
             $filename = $this->get('destination') . '/' . basename($data['file']);
             $file = $this->getFilePath($data['file']);
-            if ( file_exists($file) === false || !is_readable($file) ) {
+            if (file_exists($file) === false || !is_readable($file)) {
                 $flagWithError = __('The file uploaded is no longer available. Please check that it exists, and is readable.');
             }
 
@@ -287,14 +287,14 @@ class FieldUpload extends Field implements ExportableField, ImportableField
         }
 
         $input = Widget::Input('fields'.$fieldnamePrefix.'['.$this->get('element_name').']'.$fieldnamePostfix, $filename, ($filename ? 'hidden' : 'file'));
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
 
         $span->appendChild($input);
         $label->appendChild($span);
 
-        if ( $flagWithError != null ) {
+        if ($flagWithError != null) {
             $wrapper->appendChild(Widget::Error($label, $flagWithError));
         } else {
             $wrapper->appendChild($label);
@@ -303,10 +303,10 @@ class FieldUpload extends Field implements ExportableField, ImportableField
 
     public function validateFilename($file, &$message)
     {
-        if ( $this->get('validator') != null ) {
+        if ($this->get('validator') != null) {
             $rule = $this->get('validator');
 
-            if ( General::validateString($file, $rule) === false ) {
+            if (General::validateString($file, $rule) === false) {
                 $message = __('File chosen in ‘%s’ does not match allowable file types for that field.', array(
                     $this->get('label')
                 ));
@@ -319,7 +319,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
         else {
             $blacklist = Symphony::Configuration()->get('upload_blacklist', 'admin');
 
-            if ( !empty($blacklist) && General::validateString($file, $blacklist) ) {
+            if (!empty($blacklist) && General::validateString($file, $blacklist)) {
                 $message = __('File chosen in ‘%s’ is blacklisted for that field.', array(
                     $this->get('label')
                 ));
@@ -347,7 +347,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
                 && $data['error'] == UPLOAD_ERR_NO_FILE
             )
         ) {
-            if ( $this->get('required') === 'yes' ) {
+            if ($this->get('required') === 'yes') {
                 $message = __('‘%s’ is a required field.', array($this->get('label')));
 
                 return self::__MISSING_FIELDS__;
@@ -357,9 +357,9 @@ class FieldUpload extends Field implements ExportableField, ImportableField
         }
 
         // Its not an array, so just retain the current data and return
-        if ( is_array($data) === false ) {
+        if (is_array($data) === false) {
             $file = $this->getFilePath(basename($data));
-            if ( file_exists($file) === false || !is_readable($file) ) {
+            if (file_exists($file) === false || !is_readable($file)) {
                 $message = __('The file uploaded is no longer available. Please check that it exists, and is readable.');
 
                 return self::__INVALID_FIELDS__;
@@ -370,13 +370,13 @@ class FieldUpload extends Field implements ExportableField, ImportableField
             return $this->validateFilename($file, $message);
         }
 
-        if ( is_dir(DOCROOT . $this->get('destination') . '/') === false ) {
+        if (is_dir(DOCROOT . $this->get('destination') . '/') === false) {
             $message = __('The destination directory, %s, does not exist.', array(
                 '<code>' . $this->get('destination') . '</code>'
             ));
 
             return self::__ERROR__;
-        } elseif ( is_writable(DOCROOT . $this->get('destination') . '/') === false ) {
+        } elseif (is_writable(DOCROOT . $this->get('destination') . '/') === false) {
             $message = __('Destination folder is not writable.')
                 . ' '
                 . __('Please check permissions on %s.', array(
@@ -386,7 +386,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
             return self::__ERROR__;
         }
 
-        if ( $data['error'] != UPLOAD_ERR_NO_FILE && $data['error'] != UPLOAD_ERR_OK ) {
+        if ($data['error'] != UPLOAD_ERR_NO_FILE && $data['error'] != UPLOAD_ERR_OK) {
             switch ($data['error']) {
                 case UPLOAD_ERR_INI_SIZE:
                     $message = __('File chosen in ‘%1$s’ exceeds the maximum allowed upload size of %2$s specified by your host.', array($this->get('label'), (is_numeric(ini_get('upload_max_filesize')) ? General::formatFilesize(ini_get('upload_max_filesize')) : ini_get('upload_max_filesize'))));
@@ -420,7 +420,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
     {
         $status = self::__OK__;
 
-        if ( $data === null ) {
+        if ($data === null) {
             return array(
                 'file' =>       null,
                 'mimetype' =>   null,
@@ -430,7 +430,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
         }
 
         // Its not an array, so just retain the current data and return:
-        if ( is_array($data) === false ) {
+        if (is_array($data) === false) {
             $file = $this->getFilePath(basename($data));
 
             $result = array(
@@ -441,25 +441,25 @@ class FieldUpload extends Field implements ExportableField, ImportableField
             );
 
             // Grab the existing entry data to preserve the MIME type and size information
-            if ( isset($entry_id) ) {
+            if (isset($entry_id)) {
                 $row = $this->getCurrentValues($entry_id);
 
-                if ( empty($row) === false ) {
+                if (empty($row) === false) {
                     $result = $row;
                 }
             }
 
             // Found the file, add any missing meta information:
-            if ( file_exists($file) && is_readable($file) ) {
-                if ( empty($result['mimetype']) ) {
+            if (file_exists($file) && is_readable($file)) {
+                if (empty($result['mimetype'])) {
                     $result['mimetype'] = General::getMimeType($file);
                 }
 
-                if ( empty($result['size']) ) {
+                if (empty($result['size'])) {
                     $result['size'] = filesize($file);
                 }
 
-                if ( empty($result['meta']) ) {
+                if (empty($result['meta'])) {
                     $result['meta'] = serialize(static::getMetaInfo($file, $result['mimetype']));
                 }
 
@@ -472,12 +472,12 @@ class FieldUpload extends Field implements ExportableField, ImportableField
             return $result;
         }
 
-        if ( $simulate && is_null($entry_id) ) {
+        if ($simulate && is_null($entry_id)) {
             return $data;
         }
 
         // Check to see if the entry already has a file associated with it:
-        if ( is_null($entry_id) === false ) {
+        if (is_null($entry_id) === false) {
             $row = $this->getCurrentValues($entry_id);
 
             $existing_file = isset($row['file']) ? $this->getFilePath($row['file']) : null;
@@ -493,11 +493,11 @@ class FieldUpload extends Field implements ExportableField, ImportableField
         }
 
         // Do not continue on upload error:
-        if ( $data['error'] == UPLOAD_ERR_NO_FILE || $data['error'] != UPLOAD_ERR_OK ) {
+        if ($data['error'] == UPLOAD_ERR_NO_FILE || $data['error'] != UPLOAD_ERR_OK) {
             return false;
         }
 
-        if ( !isset($data['name']) ) {
+        if (!isset($data['name'])) {
             return array(
                 'file' =>       null,
                 'mimetype' =>   null,
@@ -516,7 +516,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
         // If a file already exists, then rename the file being uploaded by
         // adding `_1` to the filename. If `_1` already exists, the logic
         // will keep adding 1 until a filename is available (#672)
-        if ( file_exists($abs_path . '/' . $data['name']) ) {
+        if (file_exists($abs_path . '/' . $data['name'])) {
             $extension = General::getExtension($data['name']);
             $new_file = substr($abs_path . '/' . $data['name'], 0, -1 - strlen($extension));
             $count = 1;
@@ -540,7 +540,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
             Symphony::Configuration()->get('write_mode', 'file')
         );
 
-        if ( $uploaded === false ) {
+        if ($uploaded === false) {
             $message = __(
                 __('There was an error while trying to upload the file %1$s to the target directory %2$s.'),
                 array(
@@ -595,7 +595,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
     public function appendFormattedElement(XMLElement &$wrapper, $data, $encode = false, $mode = null, $entry_id = null)
     {
         // It is possible an array of null data will be passed in. Check for this.
-        if ( !is_array($data) || !isset($data['file']) || is_null($data['file']) ) {
+        if (!is_array($data) || !isset($data['file']) || is_null($data['file'])) {
             return;
         }
 
@@ -615,7 +615,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
 
         $m = unserialize($data['meta']);
 
-        if ( is_array($m) && !empty($m) ) {
+        if (is_array($m) && !empty($m)) {
             $item->appendChild(new XMLElement('meta', null, $m));
         }
 
@@ -624,11 +624,11 @@ class FieldUpload extends Field implements ExportableField, ImportableField
 
     public function prepareTableValue($data, XMLElement $link = null, $entry_id = null)
     {
-        if ( isset($data['file']) === false || !$file = $data['file'] ) {
+        if (isset($data['file']) === false || !$file = $data['file']) {
             return parent::prepareTableValue(null, $link, $entry_id);
         }
 
-        if ( $link ) {
+        if ($link) {
             $link->setValue(basename($file));
             $link->setAttribute('data-path', $this->get('destination'));
 
@@ -643,7 +643,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
     
     public function prepareTextValue($data, $entry_id = null)
     {
-        if ( isset($data['file']) ) {
+        if (isset($data['file'])) {
             return $data['file'];
         }
         return null;
@@ -675,9 +675,9 @@ class FieldUpload extends Field implements ExportableField, ImportableField
         $message = $status = null;
         $modes = (object)$this->getImportModes();
 
-        if ( $mode === $modes->getValue ) {
+        if ($mode === $modes->getValue) {
             return $data;
-        } elseif ( $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->getPostdata) {
             return $this->processRawFieldData($data, $status, $message, true, $entry_id);
         }
 
@@ -719,25 +719,25 @@ class FieldUpload extends Field implements ExportableField, ImportableField
 
         // No file, or the file that the entry is meant to have no
         // longer exists.
-        if ( !isset($data['file']) || !is_file($filepath) ) {
+        if (!isset($data['file']) || !is_file($filepath)) {
             return null;
         }
 
-        if ( $mode === $modes->getFilename ) {
+        if ($mode === $modes->getFilename) {
             return $data['file'];
         }
 
-        if ( $mode === $modes->getObject ) {
+        if ($mode === $modes->getObject) {
             $object = (object)$data;
 
-            if ( isset($object->meta) ) {
+            if (isset($object->meta)) {
                 $object->meta = unserialize($object->meta);
             }
 
             return $object;
         }
 
-        if ( $mode === $modes->getPostdata ) {
+        if ($mode === $modes->getPostdata) {
             return $data['file'];
         }
     }
@@ -750,21 +750,21 @@ class FieldUpload extends Field implements ExportableField, ImportableField
     {
         $field_id = $this->get('id');
 
-        if ( preg_match('/^mimetype:/', $data[0]) ) {
+        if (preg_match('/^mimetype:/', $data[0])) {
             $data[0] = str_replace('mimetype:', '', $data[0]);
             $column = 'mimetype';
-        } elseif ( preg_match('/^size:/', $data[0]) ) {
+        } elseif (preg_match('/^size:/', $data[0])) {
             $data[0] = str_replace('size:', '', $data[0]);
             $column = 'size';
         } else {
             $column = 'file';
         }
 
-        if ( self::isFilterRegex($data[0]) ) {
+        if (self::isFilterRegex($data[0])) {
             $this->buildRegexSQL($data[0], array($column), $joins, $where);
-        } elseif ( self::isFilterSQL($data[0]) ) {
+        } elseif (self::isFilterSQL($data[0])) {
             $this->buildFilterSQL($data[0], array($column), $joins, $where);
-        } elseif ( $andOperation ) {
+        } elseif ($andOperation) {
             foreach ($data as $value) {
                 $this->_key++;
                 $value = $this->cleanValue($value);
@@ -778,11 +778,11 @@ class FieldUpload extends Field implements ExportableField, ImportableField
                 ";
             }
         } else {
-            if ( !is_array($data) ) {
+            if (!is_array($data)) {
                 $data = array($data);
             }
 
-            foreach ( $data as &$value ) {
+            foreach ($data as &$value) {
                 $value = $this->cleanValue($value);
             }
 
@@ -807,7 +807,7 @@ class FieldUpload extends Field implements ExportableField, ImportableField
 
     public function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC')
     {
-        if ( $this->isRandomOrder($order) ) {
+        if ($this->isRandomOrder($order)) {
             $sort = 'ORDER BY RAND()';
         } else {
             $sort = sprintf(
@@ -835,14 +835,27 @@ class FieldUpload extends Field implements ExportableField, ImportableField
 
     public function getExampleFormMarkup()
     {
+        $fieldId = $this->get('id');
+        $fieldName = $this->get('element_name');
+
+        $div = new XMLElement('div', null, array('class' => 'form-field'));
         $label = Widget::Label($this->get('label'));
+        $label->setAttribute('for', $fieldName . '-' . $fieldId);
+        if ($this->get('required') === 'yes') {
+            $mark = new XMLElement('span', '*');
+            $mark->setAttribute('aria-hidden', 'true');
+            $mark->setAttribute('class', 'required-mark');
+            $label->appendChild($mark);
+        }
         $input = Widget::Input('fields['.$this->get('element_name').']', null, 'file');
-        if ( $this->get('required') === 'yes' ) {
+        $input->setAttribute('id', $fieldName . '-' . $fieldId);
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
 
-        $label->appendChild($input);
+        $div->appendChild($label);
+        $div->appendChild($input);
 
-        return $label;
+        return $div;
     }
 }

--- a/symphony/lib/toolkit/fields/field.url.php
+++ b/symphony/lib/toolkit/fields/field.url.php
@@ -98,7 +98,7 @@ class FieldUrl extends Field
 
     public function commit()
     {
-        if ( !parent::commit() ) return false;
+        if (!parent::commit()) return false;
 
         return FieldManager::saveSettings($this->get('id'), [
             'placeholder' => $this->get('placeholder'),
@@ -115,20 +115,20 @@ class FieldUrl extends Field
 
         $input = Widget::input("fields{$fieldnamePrefix}[{$this->get('element_name')}]{$fieldnamePostfix}", $value, 'url');
         $input->setAttribute('autocapitalize', 'off');
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
-        if ( $this->get('placeholder') !== null ) {
+        if ($this->get('placeholder') !== null) {
             $input->setAttribute('placeholder', $this->get('placeholder'));
         }
 
         $label = Widget::label($this->get('label'));
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
             $label->appendChild(new XMLElement('i', __('Optional')));
         }
         $label->appendChild($input);
 
-        if ( $flagWithError != null ) {
+        if ($flagWithError != null) {
             $wrapper->appendChild(Widget::Error($label, $flagWithError));
         } else {
             $wrapper->appendChild($label);
@@ -142,7 +142,7 @@ class FieldUrl extends Field
         $element = new XMLElement($this->get('element_name'), $value);
 
         // Return additional attribute 'placeholder'
-        if ( $this->get('placeholder') !== null ) {
+        if ($this->get('placeholder') !== null) {
             $element->setAttribute('placeholder', $this->get('placeholder'));
         }
 
@@ -151,27 +151,32 @@ class FieldUrl extends Field
 
     public function getExampleFormMarkup()
     {
-        $label = new XMLElement('label', $this->get('label'));
+        $fieldId = $this->get('id');
+        $fieldName = $this->get('element_name');
 
+        $div = new XMLElement('div', null, array('class' => 'form-field'));
+        $label = Widget::Label($this->get('label'));
+        $label->setAttribute('for', $fieldName . '-' . $fieldId);
         if ($this->get('required') === 'yes') {
             $mark = new XMLElement('span', '*');
-            $mark->setAttribute('aria-label', 'Required field');
+            $mark->setAttribute('aria-hidden', 'true');
             $mark->setAttribute('class', 'required-mark');
             $label->appendChild($mark);
         }
-
-        $input = Widget::input('fields['.$this->get('element_name').']', null, 'url');
+        $input = Widget::input('fields[' . $fieldName . ']', null, 'url');
+        $input->setAttribute('id', $fieldName . '-' . $fieldId);
         $input->setAttribute('autocapitalize', 'off');
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
-        if ( $this->get('placeholder') !== null ) {
+        if ($this->get('placeholder') !== null) {
             $input->setAttribute('placeholder', $this->get('placeholder'));
         }
 
-        $label->appendChild($input);
+        $div->appendChild($label);
+        $div->appendChild($input);
 
-        return $label;
+        return $div;
     }
 
     public function checkPostFieldData($data, &$message, $entry_id = null)
@@ -182,13 +187,13 @@ class FieldUrl extends Field
         );
         $message = null;
 
-        if ( $this->get('required') === 'yes' && strlen($data) === 0 ) {
+        if ($this->get('required') === 'yes' && strlen($data) === 0) {
             $message = $messages['required'];
             return self::__MISSING_FIELDS__;
         }
 
-        if ( strlen($data) !== 0 ) {
-            if ( !filter_var($data, FILTER_VALIDATE_URL) ) {
+        if (strlen($data) !== 0) {
+            if (!filter_var($data, FILTER_VALIDATE_URL)) {
                 $message = $messages['invalid'];
                 return self::__INVALID_FIELDS__;
             }
@@ -201,7 +206,7 @@ class FieldUrl extends Field
     {
         $status = self::__OK__;
 
-        if ( strlen(trim($data)) == 0 ) return array();
+        if (strlen(trim($data)) == 0) return array();
 
         $result = array(
             'value' => $data
@@ -228,9 +233,9 @@ class FieldUrl extends Field
         $message = $status = null;
         $modes = (object)$this->getImportModes();
 
-        if ( $mode === $modes->getValue ) {
+        if ($mode === $modes->getValue) {
             return $data;
-        } else if ( $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->getPostdata) {
             return $this->processRawFieldData($data, $status, $message, true, $entry_id);
         }
 
@@ -268,7 +273,7 @@ class FieldUrl extends Field
         $modes = (object)$this->getExportModes();
 
         // Export unformatted:
-        if ( $mode === $modes->getUnformatted || $mode === $modes->getPostdata ) {
+        if ($mode === $modes->getUnformatted || $mode === $modes->getPostdata) {
             return isset($data['value'])
                 ? $data['value']
                 : null;
@@ -311,16 +316,16 @@ class FieldUrl extends Field
 
     public function groupRecords($records)
     {
-        if ( !is_array($records) || empty($records) ) return;
+        if (!is_array($records) || empty($records)) return;
 
         $groups = array($this->get('element_name') => array());
 
-        foreach ( $records as $r ) {
+        foreach ($records as $r) {
             $data = $r->getData($this->get('id'));
 
             $value = $data['value'];
 
-            if ( !isset($groups[$this->get('element_name')][$value]) ) {
+            if (!isset($groups[$this->get('element_name')][$value])) {
                 $groups[$this->get('element_name')][$value] = array(
                     'attr' => array('value' => $value),
                     'records' => array(),

--- a/symphony/lib/toolkit/fields/field.week.php
+++ b/symphony/lib/toolkit/fields/field.week.php
@@ -34,7 +34,7 @@ class FieldWeek extends Field
         return 0;
     }
 
-    protected static function getWeekIndex(string $weekValue): int|float
+    protected static function getWeekIndex(string $weekValue): int
     {
         if (preg_match('/^(\d{4})-W(\d{2})$/', $weekValue, $matches)) {
             $year = (int)$matches[1];
@@ -112,7 +112,7 @@ class FieldWeek extends Field
         $default = new XMLElement('label', __('Set current week as value'));
         $default->setAttribute('class', 'column');
         $input = Widget::Input('fields['.$this->get('sortorder').'][default_week]', 'on', 'checkbox');
-        if ( $this->get('default_week') === 'on' ) {
+        if  ($this->get('default_week') === 'on') {
             $input->setAttribute('checked', 'checked');
         }
         $default->appendChild($input);
@@ -121,9 +121,6 @@ class FieldWeek extends Field
         $custom = new XMLElement('label', __('Custom week <i>optional</i>'));
         $custom->setAttribute('class', 'column');
         $input = Widget::input('fields['.$this->get('sortorder').'][custom_week]', $this->get('custom_week'), 'week');
-        // Input type="week" is not yet supported by Firefox and Safari
-        $input->setAttribute('placeholder', 'yyyy-Www');
-        $input->setAttribute('aria-label', 'Please enter a week in the format “yyyy-Www”');
         $custom->appendChild($input);
 
         $div = new XMLElement('div', null, array('class' => 'two columns'));
@@ -135,18 +132,12 @@ class FieldWeek extends Field
         $min = new XMLElement('label', __('Earliest year and week to accept <i>optional</i>'));
         $min->setAttribute('class', 'column');
         $input = Widget::input('fields['.$this->get('sortorder').'][min]', $this->get('min'), 'week');
-        // Input type="week" is not yet supported by Firefox and Safari
-        $input->setAttribute('placeholder', 'yyyy-Www');
-        $input->setAttribute('aria-label', 'Please enter a week in the format “yyyy-Www”');
         $min->appendChild($input);
 
         // Max
         $max = new XMLElement('label', __('Latest year and week <i>optional</i>'));
         $max->setAttribute('class', 'column');
         $input = Widget::input('fields['.$this->get('sortorder').'][max]', $this->get('max'), 'week');
-        // Input type="week" is not yet supported by Firefox and Safari
-        $input->setAttribute('placeholder', 'yyyy-Www');
-        $input->setAttribute('aria-label', 'Please enter a week in the format “yyyy-Www”');
         $max->appendChild($input);
 
         $div = new XMLElement('div', null, array('class' => 'two columns'));
@@ -183,7 +174,7 @@ class FieldWeek extends Field
 
     public function commit()
     {
-        if ( !parent::commit() ) return false;
+        if (!parent::commit()) return false;
 
         return FieldManager::saveSettings($this->get('id'), [
             'default_week' => $this->get('default_week') === 'on' ? 'on' : 'off',
@@ -202,40 +193,46 @@ class FieldWeek extends Field
     {
         $value = isset($data['value']) ? $data['value'] : null;
 
-        $input = Widget::input("fields{$fieldnamePrefix}[{$this->get('element_name')}]{$fieldnamePostfix}", $value, 'week', [
+        $fieldId = $this->get('id');
+        $fieldName = $this->get('element_name');
+
+        $input = Widget::input("fields{$fieldnamePrefix}[{$fieldName}]{$fieldnamePostfix}", $value, 'week', [
             'step' => $this->get('step') ?: 1
         ]);
-        // Input type="week" is not yet supported by Firefox and Safari
-        $input->setAttribute('placeholder', 'yyyy-Www');
-        $input->setAttribute('aria-label', 'Please enter a week in the format “yyyy-Www”');
-        if ( isset($data['value']) ) {
+        if (isset($data['value'])) {
             $input->setAttribute('value', $data['value']);
-        }
-        else if ( $value === null && $this->get('default_week') === 'on' ) {
+        } elseif ($value === null && $this->get('default_week') === 'on') {
             $input->setAttribute('value', date('Y-\WW'));
-        }
-        else if ( $value === null && $this->get('custom_week') !== null ) {
+        } elseif ($value === null && $this->get('custom_week') !== null) {
             $input->setAttribute('value', $this->get('custom_week'));
         }
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
 
-        if ( $this->get('min') !== null ) {
+        if ($this->get('min') !== null) {
             $input->setAttribute('min', $this->get('min'));
         }
 
-        if ( $this->get('max') !== null ) {
+        if ($this->get('max') !== null) {
             $input->setAttribute('max', $this->get('max'));
         }
 
         $label = Widget::label($this->get('label'));
-        if ( $this->get('required') !== 'yes' ) {
+        if ($this->get('required') !== 'yes') {
             $label->appendChild(new XMLElement('i', __('Optional')));
         }
-        $label->appendChild($input);
 
-        if ( $flagWithError != null ) {
+        $input->setAttribute('aria-describedby', $fieldName . '-' . $fieldId . '-hint');
+
+        $hint = new XMLElement('small', __('Enter a week (format: yyyy-Www, e.g. 2026-W17)'));
+        $hint->setAttribute('class', 'help field-hint');
+        $hint->setAttribute('id', $fieldName . '-' . $fieldId . '-hint');
+
+        $label->appendChild($input);
+        $label->appendChild($hint);
+
+        if ($flagWithError != null) {
             $wrapper->appendChild(Widget::Error($label, $flagWithError));
         } else {
             $wrapper->appendChild($label);
@@ -249,15 +246,15 @@ class FieldWeek extends Field
         $element = new XMLElement($this->get('element_name'), $value);
 
         // Return additional attributes 'min', 'max' and 'step'
-        if ( $this->get('min') !== null ) {
+        if ($this->get('min') !== null) {
             $element->setAttribute('min', $this->get('min'));
         }
 
-        if ( $this->get('max') !== null ) {
+        if ($this->get('max') !== null) {
             $element->setAttribute('max', $this->get('max'));
         }
 
-        if ( $this->get('step') !== null ) {
+        if ($this->get('step') !== null) {
             $element->setAttribute('step', $this->get('step'));
         }
 
@@ -266,44 +263,53 @@ class FieldWeek extends Field
 
     public function getExampleFormMarkup()
     {
-        $labelText = $this->get('label') . "\n<!-- Input type=\"week\" is not yet supported by Firefox and Safari. Use placeholder and aria-label to help users enter a valid value. -->";
-        $label = new XMLElement('label');
-        $label->setValue($labelText . ' ');
+        $fieldId = $this->get('id');
+        $fieldName = $this->get('element_name');
 
+        $div = new XMLElement('div', __("\n<!-- input[type=\"week\"] may fall back to a text field in some browsers. A format hint is included to ensure valid input. -->"), array('class' => 'form-field'));
+
+        $label = Widget::Label($this->get('label'));
+        $label->setAttribute('for', $fieldName . '-' . $fieldId);
         if ($this->get('required') === 'yes') {
             $mark = new XMLElement('span', '*');
-            $mark->setAttribute('aria-label', 'Required field');
+            $mark->setAttribute('aria-hidden', 'true');
             $mark->setAttribute('class', 'required-mark');
             $label->appendChild($mark);
         }
 
-        $input = Widget::input('fields['.$this->get('element_name').']', null, 'week', array(
+        $input = Widget::input('fields['. $fieldName .']', null, 'week', array(
             'step' => $this->get('step') ?: 1
         ));
-        // Input type="week" is not yet supported by Firefox and Safari
-        $input->setAttribute('placeholder', 'yyyy-Www');
-        $input->setAttribute('aria-label', 'Please enter a week in the format “yyyy-Www”');
-        if ( $this->get('custom_week') !== null ) {
+        $input->setAttribute('id', $fieldName . '-' . $fieldId);
+        if ($this->get('custom_week') !== null) {
             $input->setAttribute('value', $this->get('custom_week'));
         }
-        if ( $this->get('default_week') === 'on' ) {
-            $input->setAttribute('value', '{concat(/data/params/this-year, \'-W\', /data/params/this-week-number)}');
+        if ($this->get('default_week') === 'on') {
+            $input->setAttribute('value', "{concat(/data/params/this-year, &apos;-W&apos;, /data/params/this-week-number)}");
         }
-        if ( $this->get('required') === 'yes' ) {
+        if ($this->get('required') === 'yes') {
             $input->setAttribute('required', 'required');
         }
 
-        if ( $this->get('min') !== null ) {
+        if ($this->get('min') !== null) {
             $input->setAttribute('min', $this->get('min'));
         }
 
-        if ( $this->get('max') !== null ) {
+        if ($this->get('max') !== null) {
             $input->setAttribute('max', $this->get('max'));
         }
 
-        $label->appendChild($input);
+        $input->setAttribute('aria-describedby', $fieldName . '-' . $fieldId . '-hint');
 
-        return $label;
+        $hint = new XMLElement('small', __('Enter a week (format: yyyy-Www, e.g. 2026-W17)'));
+        $hint->setAttribute('class', 'field-hint');
+        $hint->setAttribute('id', $fieldName . '-' . $fieldId . '-hint');
+
+        $div->appendChild($label);
+        $div->appendChild($input);
+        $div->appendChild($hint);
+
+        return $div;
     }
 
     public function checkPostFieldData($data, &$message, $entry_id = null)
@@ -322,23 +328,23 @@ class FieldWeek extends Field
         );
         $message = null;
 
-        if ( $this->get('required') === 'yes' && strlen($data) === 0 ) {
+        if ($this->get('required') === 'yes' && strlen($data) === 0) {
             $message = $messages['required'];
             return self::__MISSING_FIELDS__;
         }
 
-        if ( strlen($data) > 0 && !preg_match('/^\d{4}-W(0[1-9]|[1-4][0-9]|5[0-3])$/', $data) ) {
+        if (strlen($data) > 0 && !preg_match('/^\d{4}-W(0[1-9]|[1-4][0-9]|5[0-3])$/', $data)) {
             $message = $messages['invalid'];
             return self::__INVALID_FIELDS__;
         }
 
-        if ( preg_match('/^\d{4}-W(0[1-9]|[1-4][0-9]|5[0-3])$/', $data) ) {
-            if ( $min !== null && $data < $min ) {
+        if (preg_match('/^\d{4}-W(0[1-9]|[1-4][0-9]|5[0-3])$/', $data)) {
+            if ($min !== null && $data < $min) {
                 $message = $messages['min'];
                 return self::__INVALID_FIELDS__;
             }
 
-            if ( $data > $max ) {
+            if ($data > $max) {
                 $message = $messages['max'];
                 return self::__INVALID_FIELDS__;
             }
@@ -347,14 +353,14 @@ class FieldWeek extends Field
                 $minTmp = '1970-W01'; // Default is first week of 1970 ("1970-W01").
 
                 $dataWeek = static::getWeekIndex($data);
-                if ( $min === null ) {
+                if ($min === null) {
                     $minWeek = static::getWeekIndex($minTmp);
                 } else {
                     $minWeek = static::getWeekIndex($min);
                 }
                 $relative = $dataWeek - $minWeek;
                 if (fmod($relative, $step) !== 0.0) {
-                    if ( $min === null ) {
+                    if ($min === null) {
                         $message = $messages['step_relative'];
                     } else {
                         $message = $messages['step_absolute'];
@@ -372,7 +378,7 @@ class FieldWeek extends Field
     {
         $status = self::__OK__;
 
-        if ( strlen(trim($data)) == 0 ) return array();
+        if (strlen(trim($data)) == 0) return array();
 
         $result = array(
             'value' => $data
@@ -399,9 +405,9 @@ class FieldWeek extends Field
         $message = $status = null;
         $modes = (object)$this->getImportModes();
 
-        if ( $mode === $modes->getValue ) {
+        if ($mode === $modes->getValue) {
             return $data;
-        } else if ( $mode === $modes->getPostdata ) {
+        } elseif ($mode === $modes->getPostdata) {
             return $this->processRawFieldData($data, $status, $message, true, $entry_id);
         }
 
@@ -439,7 +445,7 @@ class FieldWeek extends Field
         $modes = (object)$this->getExportModes();
 
         // Export unformatted:
-        if ( $mode === $modes->getUnformatted || $mode === $modes->getPostdata ) {
+        if ($mode === $modes->getUnformatted || $mode === $modes->getPostdata) {
             return isset($data['value'])
                 ? $data['value']
                 : null;
@@ -531,16 +537,16 @@ class FieldWeek extends Field
 
     public function groupRecords($records)
     {
-        if ( !is_array($records) || empty($records) ) return;
+        if (!is_array($records) || empty($records)) return;
 
         $groups = array($this->get('element_name') => array());
 
-        foreach ( $records as $r ) {
+        foreach ($records as $r) {
             $data = $r->getData($this->get('id'));
 
             $value = $data['value'];
 
-            if ( !isset($groups[$this->get('element_name')][$value]) ) {
+            if (!isset($groups[$this->get('element_name')][$value])) {
                 $groups[$this->get('element_name')][$value] = array(
                     'attr' => array('value' => $value),
                     'records' => array(),


### PR DESCRIPTION
This commit standardizes the generated example front-end form markup across all field types and fixes several accessibility and validation issues.

__Changes__

- Replaced implicit label wrapping with explicit label/input association using `for` and `id` attributes for all fields

Old pattern:
```html
<label>
  Label
  <input />
</label>
```  

New pattern:
```html
<div class="form-field">
  <label for="element_name-id">Label</label>
  <input id="element_name-id" />
</div>
```
- Introduced a consistent wrapper element (`div.form-field`) for all fields to simplify styling and layout handling

- Fixed WAVE accessibility warning ("orphaned label") by avoiding ambiguous label structures

- Removed `required` attribute from `input[type="range"]` and `input[type="color"]` as these inputs always submit a value and do not support the `required` attribute per HTML specification

- Removed invalid `aria-label` usage from required markers and replaced with `aria-hidden="true"`

- Unified required field indicator across all field types using:
  `<span aria-hidden="true" class="required-mark">*</span>`

__Notes__

- The new markup improves accessibility, consistency, and maintainability
- Backend markup remains unchanged for now and will be addressed separately during the planned backend redesign