### PR TITLE
fix: handle deprecated curl_close() and xml_parser_free() in PHP 8.5

### DIFF
--- a/symphony/lib/toolkit/class.gateway.php
+++ b/symphony/lib/toolkit/class.gateway.php
@@ -347,7 +347,11 @@ class Gateway
             $this->_info_last['curl_error'] = curl_errno($ch);
 
             // Close the connection
-            curl_close($ch);
+            if (PHP_VERSION_ID >= 80000) {
+                unset($ch);
+            } else {
+                curl_close($ch);
+            }
 
             return $result;
         }

--- a/symphony/lib/toolkit/class.general.php
+++ b/symphony/lib/toolkit/class.general.php
@@ -166,7 +166,9 @@ class General
                 return false;
             }
 
-            xml_parser_free($_parser);
+            if (PHP_VERSION_ID < 80000) {
+                xml_parser_free($_parser);
+            }
         }
 
         return true;


### PR DESCRIPTION
Replace `curl_close()` with `unset()` for PHP ≥ 8 and restrict `xml_parser_free()` to PHP < 8 to ensure compatibility with PHP 8.5 deprecations.