### PR TITLE
Serve admin page types as 401 Unauthorized

### DIFF
--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -680,13 +680,13 @@ class FrontendPage extends XSLTPage
 
         // Make sure the user has permission to access this page
         if (!$this->is_logged_in && in_array('admin', $row['type'])) {
-            $row = PageManager::fetchPageByType('403');
+            $row = PageManager::fetchPageByType('401');
 
             if (empty($row)) {
                 Frontend::instance()->throwCustomError(
                     __('Please login to view this page.') . ' <a href="' . SYMPHONY_URL . '/login/">' . __('Take me to the login page') . '</a>.',
-                    __('Forbidden'),
-                    Page::HTTP_STATUS_FORBIDDEN
+                    __('Unauthorized'),
+                    Page::HTTP_STATUS_UNAUTHORIZED
                 );
             }
 


### PR DESCRIPTION
- Pages of the type 'admin' should be served with HTTP status code of `401` (Unauthorised).
- This no longer conflicts with the existing error page `403` (Forbidden). This error page is created during the installation of Sym8 and is primarily intended for directories without an index page.