### PR TITLE
Create page blueprints based on page types

### DIFF
--- a/symphony/content/content.blueprintspages.php
+++ b/symphony/content/content.blueprintspages.php
@@ -766,7 +766,10 @@ class contentBlueprintsPages extends AdministrationPage
                     if (empty($current)) {
                         $file_created = PageManager::createPageFiles(
                             $fields['path'],
-                            $fields['handle']
+                            $fields['handle'],
+                            null,
+                            null,
+                            $types
                         );
 
                         // Existing page, potentially rename files
@@ -775,7 +778,8 @@ class contentBlueprintsPages extends AdministrationPage
                             $fields['path'],
                             $fields['handle'],
                             $current['path'],
-                            $current['handle']
+                            $current['handle'],
+                            $types
                         );
                     }
 

--- a/symphony/lib/toolkit/class.pagemanager.php
+++ b/symphony/lib/toolkit/class.pagemanager.php
@@ -160,7 +160,7 @@ class PageManager
      * @return boolean
      *  true when the page files have been created successfully, false otherwise.
      */
-    public static function createPageFiles($new_path, $new_handle, $old_path = null, $old_handle = null)
+    public static function createPageFiles($new_path, $new_handle, $old_path = null, $old_handle = null, array $types)
     {
         $new = PageManager::resolvePageFileLocation($new_path, $new_handle);
         $old = PageManager::resolvePageFileLocation($old_path, $old_handle);
@@ -170,9 +170,20 @@ class PageManager
             return true;
         }
 
+        $normalizedTypes = array_map('strtoupper', $types);
+        $http4xx = array('400', '401', '403', '404', '429');
+
         // Old file doesn't exist, use template:
         if (!file_exists($old)) {
-            $data = file_get_contents(self::getTemplate('blueprints.page'));
+            if (in_array('XML', $normalizedTypes, true)) {
+                $data = file_get_contents(self::getTemplate('blueprints.page-xml'));
+            } elseif (in_array('JSON', $normalizedTypes, true)) {
+                $data = file_get_contents(self::getTemplate('blueprints.page-json'));
+            } elseif (count(array_intersect($normalizedTypes, $http4xx)) > 0) {
+                $data = file_get_contents(self::getTemplate('blueprints.page-4xx'));
+            } else {
+                $data = file_get_contents(self::getTemplate('blueprints.page'));
+            }
         } else {
             $data = file_get_contents($old);
         }

--- a/symphony/template/blueprints.page-4xx.xsl
+++ b/symphony/template/blueprints.page-4xx.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
-<xsl:import href="../utilities/master.xsl"/>
+<xsl:import href="../utilities/40x.xsl"/>
 
 <xsl:template match="data">
 

--- a/symphony/template/blueprints.page-json.xsl
+++ b/symphony/template/blueprints.page-json.xsl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<xsl:output method="text"
+  encoding="UTF-8" />
+
+<xsl:template match="/">
+{"title" : "<xsl:value-of select="/data/params/page-title"/>"}
+</xsl:template>
+
+</xsl:stylesheet>

--- a/symphony/template/blueprints.page-xml.xsl
+++ b/symphony/template/blueprints.page-xml.xsl
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<xsl:output method="xml"
+  omit-xml-declaration="no"
+  encoding="UTF-8"
+  indent="yes" />
+
+<xsl:template match="/">
+  <data>
+    <title><xsl:value-of select="/data/params/page-title"/></title>
+  </data>
+</xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
The function `createPageFiles` has been extended to include the `$types` array, which contains the page types.

This allows blueprints to be copied more precisely for specific page types:

- When a page of type `XML` is created, it is rendered as an XML page out of the box.
- When a page of type `JSON` is created, it is rendered as a JSON page out of the box.
- When a page of type `4xx` error page is created, the template `40x.xsl` is imported.
- When a standard HTML page is created, the `master.xsl` template is imported, so the new page is automatically displayed using the current site style.