### PR TITLE
Update extension Anti Brute Force (2.3.0)

### DIFF
--- a/extensions/anti_brute_force/LICENCE.txt
+++ b/extensions/anti_brute_force/LICENCE.txt
@@ -4,6 +4,7 @@ follows:
 
 ----- begin license block -----
 
+Copyright since 2026 Sym8
 Copyright 2012-2019 Deux Huit Huit inc.
 Copyright 2011 Solutions Nitriques inc.
 

--- a/extensions/anti_brute_force/README.md
+++ b/extensions/anti_brute_force/README.md
@@ -1,20 +1,22 @@
+![PHP 7 passing](https://img.shields.io/badge/build-passing-brightgreen?style=flat-square&logo=php&logoColor=green&label=PHP%207) ![PHP 8 passing](https://img.shields.io/badge/build-passing-brightgreen?style=flat-square&logo=php&logoColor=green&label=PHP%208)
+
 # Anti Brute Force #
 
 > Secure your Symphony backend against brute force and dictionary attacks
 
-Prevents ***people and softwares*** to brute force your authors/developers accounts.
+Prevents ___people and softwares___ to brute force your authors/developers accounts.
 
-### SPECS ###
+## Specs
 
-- After **x** failed attempt, the IP address will be banned for **y** min;  
-  **x** and **y** are settings in the preferences page 
-- Features colored list: ***Black list***, **Gray list**, *White list*.
-- Features a **unban via email** capabilities; Must be enabled in the preferences page
+- After __x__ failed attempt, the IP address will be banned for __y__ min;
+  (__x__ and __y__ are settings in the preferences page)
+- Features colored list: ___Black list___, __Gray list__, _White list_.
+- Features a __unban via email__ capabilities; Must be enabled in the preferences page
 - Backend content page for managing blocked IPs and colored lists
 - A Facade/Singleton class -ABF- for developers to leverage anti_brute_force capabilities
   (ex.: email reports or use with the member extension)
 
-### NOTES ABOUT PROXIES
+## Notes about proxies
 
 If you are using Symphony on a server that sits behind a proxy, it will always
 track 127.0.0.1 (or your proxy's IP) as remote address, simply because PHP doesn't see anything else
@@ -26,35 +28,47 @@ Most proxies will set the 'HTTP_X_FORWARDED_FOR' field with the respective user'
 but some other provider (such as CloudFlare) will create a custom field. Your best bet
 would be to do some actual penetration testing to be sure ABF works properly.
 
-### REQUIREMENTS ###
+## Compatibility
 
-- Symphony CMS version 2.4 and up (as of the day of the last release of this extension)
+The extension is compatible with legacy Symphony CMS installations as well as Sym8.
 
-### INSTALLATION ###
+## Installation
 
-- `git clone` / download and unpack the tarball file
-- (re)Name the folder ***anti_brute_force***
+- `git clone` / download and unpack the zip file
+- (re)Name the folder __anti_brute_force__
 - Put into the extension directory
-- Enable/install just like any other extension (@see <http://getsymphony.com/learn/tasks/view/install-an-extension/>)
-- (optional) Go to the *Preferences* page to customize settings
-	- Maximum failed count before user gets banned
-	- Banned duration - number of minutes IP is banned
-	- Gray list threshold - maximum number of gray list entries before black list
-	- Gray list duration - in days - before expire
-	- Unban via email - Enables/disable this feature
-	- Restrict access from authors - Hide/Show ABF content page to Authors
-	- Remote IP address field name - The `getenv()` field to look for the client's IP.
+- Enable/install just like any other extension
+- (optional) Go to the _Preferences_ page to customize settings
+    - Maximum failed count before user gets banned
+    - Banned duration - number of minutes IP is banned
+    - Gray list threshold - maximum number of gray list entries before black list
+    - Gray list duration - in days - before expire
+    - Unban via email - Enables/disable this feature
+    - Restrict access from authors - Hide/Show ABF content page to Authors
+    - Remote IP address field name - The `getenv()` field to look for the client's IP.
 - (optional) See all the banned IPs via Anti Brute Force -> Banned IPs
 - (optional) Manage colored lists entries via Anti Brute Force -> Black/Gray/White list
 - (optional) Configure a cron job to run `cron/remove_expired.php` at regular interval
 
-### UPDATING ###
+## Cron job
 
-Updating from >= 1.3 is safe.
-[Click here for older releases](https://github.com/Solutions-Nitriques/anti_brute_force/releases).
+__Note__: The cron script is __CLI-only__ and must be executed via a server-side cron job as a PHP CLI script.
+HTTP-based cron services are intentionally not supported for security reasons.
 
-### LICENSE
+Orphaned and expired banned IP entries on the banned IP list can be easily cleaned up and removed using a cron job.
 
-[MIT](http://deuxhuithuit.mit-license.org)
+Set up the cron job in the server management of your vHost, for example, once a day:
 
-Made in Montréal with love by [Deux Huit Huit](http://deuxhuithuit.com/)
+```
+0 0 * * * php /path/to/website/extensions/anti_brute_force/cron/remove_expired.php
+```
+
+After that, the following entry will be written to the log file after each execution:
+
+```
+Fri, 05 Jun 2026 10:00:28 +0000 [ABF] cleanup completed.
+```
+
+## License
+
+[MIT](https://github.com/Sym8-io/anti_brute_force?tab=License-1-ov-file)

--- a/extensions/anti_brute_force/assets/content.abf.css
+++ b/extensions/anti_brute_force/assets/content.abf.css
@@ -1,47 +1,47 @@
 /**
- * Anti Brute Force
- */
+* Anti Brute Force
+*/
 
 .actions.no-pad {
-	padding-top: 0;
+  padding-top: 0;
 }
 
 .actions.no-pad button:last-child {
-	margin-right: 0;
+  margin-right: 0;
 }
 
 .actions button.active {
-	font-weight: bold;
+  font-weight: bold;
 }
 
 table + fieldset.insert {
-	display: block;
-	margin: 1em 0 1em 1.9rem !important;
-	border-bottom: 1px solid #E4E4DE;
-	padding-bottom: 0;
+  display: block;
+  margin: 1em 0 1em 1.9rem !important;
+  border-bottom: 1px solid #E4E4DE;
+  padding-bottom: 0;
 }
 
 fieldset.insert legend {
-	margin-left: 1rem;
+  margin-left: 1rem;
 }
 
 fieldset.insert label {
-	width: auto;
-	display: inline-block;
+  width: auto;
+  display: inline-block;
 }
 
 fieldset.insert label .input-ip {
-	width: 150px;
-	margin-top: 0;
-	vertical-align: top;
+  width: 150px;
+  margin-top: 0;
+  vertical-align: top;
 }
 
 fieldset.insert label .input-submit {
-	margin-top: 0;
-	vertical-align: top;
+  margin-top: 0;
+  vertical-align: top;
 }
 
 fieldset.insert  .actions{
-	float: right;
-	padding-top: 0px;
+  float: right;
+  padding-top: 0px;
 }

--- a/extensions/anti_brute_force/content/content.login.php
+++ b/extensions/anti_brute_force/content/content.login.php
@@ -22,6 +22,19 @@ class contentExtensionAnti_brute_forceLogin extends contentLogin
     private $_email_sent = null;
 
     /**
+     * Testing the Pico CSS login style to ensure backward compatibility
+     * with the old Symphony style in a minimally invasive way.
+     */
+    private function oldSymphony()
+    {
+        if (!file_exists(SYMPHONY . '/assets/css/pico-login.css')) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
      *
      * Overrides the view method
      */
@@ -41,7 +54,7 @@ class contentExtensionAnti_brute_forceLogin extends contentLogin
             // evil users won't be able to detect anything from the response
             // they *should* still be blocked since guessing a hash is
             // practically infeasible
-            redirect(SYMPHONY_URL);
+            redirect(SYMPHONY_URL . '/login/');
             die();
 
         } else {
@@ -54,53 +67,104 @@ class contentExtensionAnti_brute_forceLogin extends contentLogin
 
             $this->setTitle(sprintf('%1$s &ndash; %2$s', __('Unban via email'), __('Symphony')));
 
-            $this->Form = Widget::Form('', 'post');
-            $this->Form->setAttribute('class', 'frame');
+            $main = new XMLElement('main', null);
+            if ($this->oldSymphony() === true) {
+                $main->setAttribute('class', 'container frame');
+            } else {
+                $main->setAttribute('class', 'container login');
+            }
 
-            $this->Form->appendChild(new XMLElement('h1', __('Symphony')));
+            $this->Form = Widget::Form('/symphony/extension/anti_brute_force/login/', 'post', '');
+            if ($this->oldSymphony() === false) {
+                $this->Form->setAttribute('class', 'frame');
+            }
+
+            // H1 should be appear above the form
+            $siteName = new XMLElement('h1', __('Symphony'));
+            $main->appendChild($siteName);
 
             $this->__buildFormContent();
 
-            $this->Body->appendChild($this->Form);
+            $p = new XMLElement('p', null, array('class' => 'back-to-website'));
+            $backLink = new XMLElement('a', __("back to ") . Symphony::Configuration()->get('sitename', 'general'));
+            $backLink->setAttribute('href', URL);
+            $backLink->setAttribute('class', 'secondary back-link');
+            $p->appendChild($backLink);
+
+            $main->appendChild($this->Form);
+            $main->appendChild($p);
+
+            $this->Body->appendChild($main);
         }
     }
 
     private function __buildFormContent()
     {
-        $fieldset = new XMLElement('fieldset');
+        $divInner = new XMLElement('div', null, array('class' => 'inner'));
+        $divInner->appendChild(new XMLElement('h2', __('Unban via email')));
+
+        $divField = new XMLElement('div', null, array('class' => 'form-field'));
 
         // email was not send
         // or first time here (email_sent == NULL)
         if ($this->_email_sent !== true) {
 
-            $fieldset->appendChild(new XMLElement('p', __('Enter your email address to be sent a remote unban link with further instructions.')));
+            $email = $_POST['email'] ?? null;
+
+            $divInner->appendChild(new XMLElement('p', __('Enter your email address to be sent a remote unban link with further instructions.'), array('class' => 'message info')));
 
             $label = Widget::Label(__('Email Address'));
-            $label->appendChild(Widget::Input('email', General::sanitize($_POST['email']), 'text', array('autofocus','autofocus')));
+            $label->setAttribute('for', 'userlogin');
+            // Do not set the "autofocus" attribute directly.
+            // On touch devices this can cause the virtual keyboard
+            // to open automatically, resulting in a disruptive UX.
+            //
+            // Focus handling is applied via Javascript depending on
+            // the device input type (touch vs. non-touch).
+            $input = Widget::Input('email', General::sanitize($email), 'email', array('id' => 'userlogin', 'data-autofocus' => 'true', 'required' => 'required', 'autocapitalize' => 'off', 'autocomplete' => 'email'));
 
         }
 
-        if (isset($this->_email_sent)) {
-
-            if ($this->_email_sent) {
-
-                $div = new XMLElement('div', __('Email sent. Follow the instruction in it.'));
-                $fieldset->appendChild($div);
-
+        if (isset($this->_email_error) && $this->_email_error) {
+            $alert = new XMLElement('p', __('This Symphony instance has not been set up for emailing, %s', array('<code>' . General::sanitize($this->_email_error) . '</code>')));
+            $alert->setAttribute('role', 'alert');
+            if ($this->oldSymphony() === true) {
+                $alert->setAttribute('class', 'invalid');
             } else {
-
-                $div = new XMLElement('div', NULL, array('class' => 'invalid'));
-                $div->appendChild($label);
-                $div->appendChild(new XMLElement('p', __('There was a problem locating your account. Please check that you are using the correct email address.')));
-                $fieldset->appendChild($div);
+                $alert->setAttribute('class', 'message invalid');
             }
+            $input->setAttribute('aria-invalid', 'false');
+            $divInner->appendChild($alert);
+        } elseif (isset($this->_email_sent)) {
 
-        } else {
+            if ($this->_email_sent === false) {
 
-            $fieldset->appendChild($label);
+                $errorId = 'invalid-email';
+                $errorMsg = new XMLElement('small', __('There was a problem locating your account. Please check that you are using the correct email address.'));
+                $errorMsg->setAttribute('id', $errorId);
+                $errorMsg->setAttribute('role', 'alert');
+                if ($this->oldSymphony() === true) {
+                    $errorMsg->setAttribute('class', 'invalid');
+                }
+                $input->setAttribute('aria-invalid', 'true');
+                $input->setAttribute('aria-describedby', $errorId);
+            } elseif ($this->_email_sent === true) {
+
+                $div = new XMLElement('div', __('Check your inbox. ') . __('We have sent you an email. Follow the instruction in it.'), array('class' => 'message success'));
+                $divInner->appendChild($div);
+            }
         }
 
-        $this->Form->appendChild($fieldset);
+        if (!isset($this->_email_sent) || $this->_email_sent !== true) {
+            $divField->appendChild($label);
+            $divField->appendChild($input);
+            if (isset($errorMsg)) {
+                $divField->appendChild($errorMsg);
+            }
+        }
+
+        $divInner->appendChild($divField);
+        $this->Form->appendChild($divInner);
 
         if ($this->_email_sent !== true) {
             $div = new XMLElement('div', NULL, array('class' => 'actions'));
@@ -155,7 +219,15 @@ class contentExtensionAnti_brute_forceLogin extends contentLogin
 
                 // if no default values are set
                 if (!is_array($emailSettings) || empty($emailSettings['from_address'])) {
-                    $email->setFrom($author['email'], Symphony::Configuration()->get('sitename','general'));
+                    // Do not fall back to the recipient email address as sender.
+                    // While this was common practice years ago, modern mail providers
+                    // (Google, Yahoo, Microsoft) enforce strict SPF/DKIM/DMARC policies,
+                    // making forged or mismatched sender addresses unreliable and likely
+                    // to be rejected or flagged as spam.
+                    $this->_email_sent = false;
+                    $this->_email_error = __('Sender email address cannot be empty.');
+
+                    return;
                 }
                 // use default settings, as this should help with SPF and DKIM
                 else {
@@ -165,9 +237,11 @@ class contentExtensionAnti_brute_forceLogin extends contentLogin
                 $email->setRecipients($author['email']);
                 $email->setSubject(__('Unban IP link'));
                 $email->setTextPlain(
-                    __('Please follow this link to unban your IP: ') .
-                    SYMPHONY_URL . ABF::UNBAND_LINK . $failure[0]->Hash . '/' . PHP_EOL .
-                    __('If you do not remember your password, follow the "forgot password" link on the login page.') . PHP_EOL .
+                    __('Hi %s,', array($author['first_name'])) . PHP_EOL .
+                    __('Please follow this link to unban your IP: ') . PHP_EOL . PHP_EOL .
+                    '    ' . SYMPHONY_URL . ABF::UNBAND_LINK . $failure[0]->Hash . '/' . PHP_EOL . PHP_EOL .
+                    __('If you do not remember your password, follow the "forgot password" link on the login page.') . PHP_EOL . PHP_EOL .
+                    __('Best Regards,') . PHP_EOL .
                     __('The Symphony Team')
                 );
 
@@ -177,6 +251,7 @@ class contentExtensionAnti_brute_forceLogin extends contentLogin
             } catch (Exception $e) {
                 // do nothing
                 $this->_email_sent = false;
+                $this->_email_error = $e->getMessage();
             }
         }
     }

--- a/extensions/anti_brute_force/cron/remove_expired.php
+++ b/extensions/anti_brute_force/cron/remove_expired.php
@@ -1,12 +1,20 @@
 <?php
+/**
+ * The cron script is CLI-only and must be executed via a server cron job.
+ * HTTP-based cron services are intentionally not supported for security reasons.
+ */
+if (php_sapi_name() !== 'cli') {
+    exit;
+}
 
 define('DOCROOT', str_replace('/extensions/anti_brute_force/cron', '', rtrim(dirname(__FILE__), '\\/') ));
 
 if (file_exists(DOCROOT . '/vendor/autoload.php')) {
-	require_once(DOCROOT . '/vendor/autoload.php');
-	require_once(DOCROOT . '/symphony/lib/boot/bundle.php');
+    require_once(DOCROOT . '/vendor/autoload.php');
+    require_once(DOCROOT . '/symphony/lib/boot/bundle.php');
 } else {
-	die('Failed to load symphony.');
+    echo gmdate('r') . " [ABF] Failed to load symphony.\n";
+    exit;
 }
 
 // creates the DB
@@ -15,5 +23,9 @@ Administration::instance();
 require_once(DOCROOT . '/extensions/anti_brute_force/extension.driver.php');
 
 if (!ABF::instance()->removeExpiredEntries()) {
-	die('Failed to delete');
+    echo gmdate('r') . " [ABF] Failed to delete expired entries.\n";
+    exit;
+} else {
+    echo gmdate('r') . " [ABF] cleanup completed.\n";
+    exit;
 }

--- a/extensions/anti_brute_force/extension.driver.php
+++ b/extensions/anti_brute_force/extension.driver.php
@@ -93,7 +93,7 @@ class extension_anti_brute_force extends Extension
      */
     public function fetchNavigation()
     {
-        return  array(
+        return array(
             array(
                 'location' => __(self::EXT_NAME),
                 'name' => __(self::EXT_NAME),
@@ -219,11 +219,17 @@ class extension_anti_brute_force extends Extension
      */
     private function mustCheck($oPage)
     {
-        return (!($oPage instanceof contentExtensionAnti_brute_forceLogin)) ||
-            ($oPage instanceof contentExtensionAnti_brute_forceLogin &&
-            $unBanViaEmail != 'No' &&
-            $unBanViaEmail != false &&
-            $unBanViaEmail != 'off');
+        $unBanViaEmail = Symphony::Configuration()->get('auto-unban', 'anti-brute-force');
+
+        $isLoginPage = ($oPage instanceof contentExtensionAnti_brute_forceLogin);
+        $unbanEnabled = !in_array($unBanViaEmail, ['No', 'off', false], true);
+
+        // Important: Never permanently block the login page
+        if ($isLoginPage && $unbanEnabled) {
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -332,8 +338,6 @@ class extension_anti_brute_force extends Extension
         // adds the field set to the wrapper
         $context['wrapper']->appendChild($fieldset);
     }
-
-
 
     /**
      *

--- a/extensions/anti_brute_force/extension.meta.xml
+++ b/extensions/anti_brute_force/extension.meta.xml
@@ -1,146 +1,156 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension id="anti_brute_force" status="released" xmlns="http://getsymphony.com/schemas/extension/1.0">
-    <name>Anti Brute Force</name>
-    <description>Secure your Symphony backend against brute force and dictionary attacks</description>
-    <repo type="github">https://github.com/sym8-io/sym8</repo>
-    <types>
-        <type>Workflow</type>
-        <type>Security</type>
-        <type>Login</type>
-        <type>Brute Force</type>
-    </types>
-    <authors>
-        <author>
-            <name github="sym8-io">Sym8</name>
-            <website>https://sym8.io/</website>
-        </author>
-    </authors>
-    <dependencies>
-        <!-- None -->
-    </dependencies>
-    <releases>
-        <release version="2.2.1" date="2025-05-22" min="2.7.0" max="2.x.x">
-            - Alter tables to utf8mb4
-        </release>
-        <release version="2.2.0" date="2019-09-04" min="2.7.0" max="2.x.x">
-            - Add a php script file to be able to purge old records from a cron job
-        </release>
-        <release version="2.1.3" date="2018-10-01" min="2.4" max="2.x.x">
-            - Purge opcache upon install, since Symphony 2.4+ does not do it
-        </release>
-        <release version="2.1.2" date="2018-01-17" min="2.4" max="2.x.x">
-            - Fix SQL injection in lists
-        </release>
-        <release version="2.1.1" date="2018-01-16" min="2.4" max="2.x.x">
-            - Sanitize user provided value in form
-        </release>
-        <release version="2.1.0" date="2018-01-15" min="2.4" max="2.x.x">
-            - Sanitize Widget's values
-        </release>
-        <release version="2.0.6" date="2017-12-29" min="2.4" max="2.x.x">
-            - Revert to 2.0.4 and do not try to fix other extensions
-        </release>
-        <release version="2.0.5" date="2017-11-23" min="2.4" max="2.x.x">
-            - Fix problem when the email gateway settings is not prefixed with 'email_'
-        </release>
-        <release version="2.0.4" date="2017-06-05" min="2.4" max="2.x.x">
-            - Fix #40: Properly validate IP addresses (v4 and v6)
-        </release>
-        <release version="2.0.3" date="2017-01-06" min="2.4" max="2.x.x">
-            - Fix #38: Removed inline scripts
-        </release>
-        <release version="2.0.2" date="2016-03-06" min="2.4" max="2.x.x">
-            - Fix #36: Database error with IPv6 addresses
-        </release>
-        <release version="2.0.1" date="2016-03-06" min="2.4" max="2.x.x">
-            - Updated compatibility infos
-        </release>
-        <release version="2.0.0" date="2016-01-05" min="2.4" max="2.6.x">
-            - Rename mistyped function (changes the public API)
-        </release>
-        <release version="1.4.8" date="2015-06-25" min="2.4" max="2.6.x">
-            - Fix method signature.
-            - Mark as Symphony 2.6.x compatible.
-        </release>
-        <release version="1.4.7" date="2014-08-26" min="2.4" max="2.5">
-            - Fixing Author() difference between 2.4 and 2.5
-        </release>
-        <release version="1.4.6" date="2014-08-21" min="2.4" max="2.5">
-            - Fixing issue #30 (thanks again @michael-e). The API as a new method
-            `ABF::instance()-&gt;authorLoginFailure()`
-        </release>
-        <release version="1.4.5" date="2014-07-31" min="2.4" max="2.5">
-            - Fixing issues #27 and #29 (thanks @michael-e)
-            - Revisited #19: The extension now plays better with http proxies
-            - Raw request IP value is loggued
-            - Manual entries now uses the Author name as source
-        </release>
-        <release version="1.4.4" date="2014-07-29" min="2.4" max="2.5">
-            - Fixing issues #21, #22, #23, #24, #25 and #26 (thanks @michael-e)
-            - Minor UI updates
-        </release>
-        <release version="1.4.3" date="2014-07-28" min="2.4">
-            - Fixing issue #20 and #19 completely.
-            - Update the settings UI for 2.4
-        </release>
-        <release version="1.4.2" date="2014-07-26" min="2.4">
-            - Added a note about proxies (thanks @michael-e)
-        </release>
-        <release version="1.4.1" date="2014-07-01" min="2.4">
-            - Selectable table for Symphony 2.4 (thanks @nathanhornby)
-        </release>
-        <release version="1.4" date="2013-12-06" min="2.4">
-            - Fixes for Symphony 2.4
-        </release>
-        <release version="1.3.5" date="2014-06-06" min="2.3" max="2.3.6">
-            - Added default collate values on tables.
-        </release>
-        <release version="1.3.4" date="2013-12-06" min="2.3">
-            - Fixed a bunch of typos.
-            - Added a setting for the name of the $_SERVER tag that contains the IP address. This is usefull
-            when running being a proxy, so you can get the real user IP.
-            - Fixing issue #17 - IP were not added to colored lists properly via the UI (thanks @michael-e).
-        </release>
-        <release version="1.3.3" date="2013-11-29" min="2.3">
-            - Added a default sender email address, so email can be send even if nothing is set in the preferences.
-            - Remove a left over var_dump
-        </release>
-        <release version="1.3.2" date="2013-06-28" min="2.3">
-            - Officially added Italian translation (thanks @DaveRev)
-            - Fixed a bug when no email settings are set in config.php
-        </release>
-        <release version="1.3.1" date="2012-12-18" min="2.3">
-            - Officially added Russian translation (thanks @bzerangue)
-            - Grouped navigation
-            - Added a parameter for hidding Anti Brute Force menu to authors
-            - Added alert when there are banned IPs
-        </release>
-        <release version="1.3" date="2012-11-15" min="2.3">
-            - **Major Security Update:** Make sure the extension warns the user if misconfigured:
-            **Do not fail silently.**
-            - UI Update for Symphony 2.3.
-            - Do not display the unband page if current IP is not banned.
-            - Minor security update - make sure we have an email address set and validate before send.
-            - Make the current IP the default value in the input field only for whitelist.
-        </release>
-        <release version="1.2" date="2012-10-05" min="2.3" max="2.3.0" status="deprecated">
-            - DEPRECATED - Use 1.3: If you still need support for Symphony 2.2.x, use version 1.1
-            - Compatibility update for Symphony 2.3
-        </release>
-        <release version="1.1" date="2011-07-20" min="2.2" max="2.2.5">
-            - Colored list feature added
-            - Fix issues #5, and #7
-        </release>
-        <release version="1.0.2" date="2011-07-03 " min="2.2" max="2.2.5">
-            - New data base scheme
-            - New setting group, which was a copy/paste error -- breaks downward compatibility --
-            - Fix others errors (not bugs, errors): issue  #3, #4, #6
-        </release>
-        <release version="1.0.1" date="2011-07-02" min="2.2" max="2.2.5">
-            - Fix Issues #1 (typo) and #2 (no more ASDC)
-        </release>
-        <release version="1.0" date="2011-07-01" min="2.2" max="2.2.5">
-            - First release: Block login, Admin content page, ABF Facade/Singleton
-        </release>
-    </releases>
+  <name>Anti Brute Force</name>
+  <description>Secure your Symphony backend against brute force and dictionary attacks</description>
+  <repo type="github">https://github.com/Sym8-io/anti_brute_force</repo>
+  <types>
+    <type>Workflow</type>
+    <type>Security</type>
+    <type>Login</type>
+    <type>Brute Force</type>
+  </types>
+  <authors>
+    <author>
+      <name github="sym8-io">Sym8</name>
+      <website>https://sym8.io/</website>
+    </author>
+  </authors>
+  <dependencies>
+    <!-- None -->
+  </dependencies>
+  <releases>
+    <release version="2.3.0" date="2026-06-08" min="2.7.0" max="2.x.x">
+      - Prevent global ban check on login and unban flow
+      - The structure of screen messages has been adapted to the new structure
+      - POST data is discarded only for blocked requests
+      - The cron job has been updated
+      - The structure of the "Unban IP link" message has been updated
+      - Fix: If no "From" email address defined, no unban email is sent
+      - Improved: HTTP status codes for banned and blacklisted error pages
+      - Update the README file and the license
+    </release>
+    <release version="2.2.1" date="2025-05-22" min="2.7.0" max="2.x.x">
+      - Alter tables to utf8mb4
+    </release>
+    <release version="2.2.0" date="2019-09-04" min="2.7.0" max="2.x.x">
+      - Add a php script file to be able to purge old records from a cron job
+    </release>
+    <release version="2.1.3" date="2018-10-01" min="2.4" max="2.x.x">
+      - Purge opcache upon install, since Symphony 2.4+ does not do it
+    </release>
+    <release version="2.1.2" date="2018-01-17" min="2.4" max="2.x.x">
+      - Fix SQL injection in lists
+    </release>
+    <release version="2.1.1" date="2018-01-16" min="2.4" max="2.x.x">
+      - Sanitize user provided value in form
+    </release>
+    <release version="2.1.0" date="2018-01-15" min="2.4" max="2.x.x">
+      - Sanitize Widget's values
+    </release>
+    <release version="2.0.6" date="2017-12-29" min="2.4" max="2.x.x">
+      - Revert to 2.0.4 and do not try to fix other extensions
+    </release>
+    <release version="2.0.5" date="2017-11-23" min="2.4" max="2.x.x">
+      - Fix problem when the email gateway settings is not prefixed with 'email_'
+    </release>
+    <release version="2.0.4" date="2017-06-05" min="2.4" max="2.x.x">
+      - Fix #40: Properly validate IP addresses (v4 and v6)
+    </release>
+    <release version="2.0.3" date="2017-01-06" min="2.4" max="2.x.x">
+      - Fix #38: Removed inline scripts
+    </release>
+    <release version="2.0.2" date="2016-03-06" min="2.4" max="2.x.x">
+      - Fix #36: Database error with IPv6 addresses
+    </release>
+    <release version="2.0.1" date="2016-03-06" min="2.4" max="2.x.x">
+      - Updated compatibility infos
+    </release>
+    <release version="2.0.0" date="2016-01-05" min="2.4" max="2.6.x">
+      - Rename mistyped function (changes the public API)
+    </release>
+    <release version="1.4.8" date="2015-06-25" min="2.4" max="2.6.x">
+      - Fix method signature.
+      - Mark as Symphony 2.6.x compatible.
+    </release>
+    <release version="1.4.7" date="2014-08-26" min="2.4" max="2.5">
+      - Fixing Author() difference between 2.4 and 2.5
+    </release>
+    <release version="1.4.6" date="2014-08-21" min="2.4" max="2.5">
+      - Fixing issue #30 (thanks again @michael-e). The API as a new method
+      `ABF::instance()-&gt;authorLoginFailure()`
+    </release>
+    <release version="1.4.5" date="2014-07-31" min="2.4" max="2.5">
+      - Fixing issues #27 and #29 (thanks @michael-e)
+      - Revisited #19: The extension now plays better with http proxies
+      - Raw request IP value is loggued
+      - Manual entries now uses the Author name as source
+    </release>
+    <release version="1.4.4" date="2014-07-29" min="2.4" max="2.5">
+      - Fixing issues #21, #22, #23, #24, #25 and #26 (thanks @michael-e)
+      - Minor UI updates
+    </release>
+    <release version="1.4.3" date="2014-07-28" min="2.4">
+      - Fixing issue #20 and #19 completely.
+      - Update the settings UI for 2.4
+    </release>
+    <release version="1.4.2" date="2014-07-26" min="2.4">
+      - Added a note about proxies (thanks @michael-e)
+    </release>
+    <release version="1.4.1" date="2014-07-01" min="2.4">
+      - Selectable table for Symphony 2.4 (thanks @nathanhornby)
+    </release>
+    <release version="1.4" date="2013-12-06" min="2.4">
+      - Fixes for Symphony 2.4
+    </release>
+    <release version="1.3.5" date="2014-06-06" min="2.3" max="2.3.6">
+      - Added default collate values on tables.
+    </release>
+    <release version="1.3.4" date="2013-12-06" min="2.3">
+      - Fixed a bunch of typos.
+      - Added a setting for the name of the $_SERVER tag that contains the IP address. This is usefull
+      when running being a proxy, so you can get the real user IP.
+      - Fixing issue #17 - IP were not added to colored lists properly via the UI (thanks @michael-e).
+    </release>
+    <release version="1.3.3" date="2013-11-29" min="2.3">
+      - Added a default sender email address, so email can be send even if nothing is set in the preferences.
+      - Remove a left over var_dump
+    </release>
+    <release version="1.3.2" date="2013-06-28" min="2.3">
+      - Officially added Italian translation (thanks @DaveRev)
+      - Fixed a bug when no email settings are set in config.php
+    </release>
+    <release version="1.3.1" date="2012-12-18" min="2.3">
+      - Officially added Russian translation (thanks @bzerangue)
+      - Grouped navigation
+      - Added a parameter for hidding Anti Brute Force menu to authors
+      - Added alert when there are banned IPs
+    </release>
+    <release version="1.3" date="2012-11-15" min="2.3">
+      - **Major Security Update:** Make sure the extension warns the user if misconfigured:
+      **Do not fail silently.**
+      - UI Update for Symphony 2.3.
+      - Do not display the unband page if current IP is not banned.
+      - Minor security update - make sure we have an email address set and validate before send.
+      - Make the current IP the default value in the input field only for whitelist.
+    </release>
+    <release version="1.2" date="2012-10-05" min="2.3" max="2.3.0" status="deprecated">
+      - DEPRECATED - Use 1.3: If you still need support for Symphony 2.2.x, use version 1.1
+      - Compatibility update for Symphony 2.3
+    </release>
+    <release version="1.1" date="2011-07-20" min="2.2" max="2.2.5">
+      - Colored list feature added
+      - Fix issues #5, and #7
+    </release>
+    <release version="1.0.2" date="2011-07-03 " min="2.2" max="2.2.5">
+      - New data base scheme
+      - New setting group, which was a copy/paste error -- breaks downward compatibility --
+      - Fix others errors (not bugs, errors): issue  #3, #4, #6
+    </release>
+    <release version="1.0.1" date="2011-07-02" min="2.2" max="2.2.5">
+      - Fix Issues #1 (typo) and #2 (no more ASDC)
+    </release>
+    <release version="1.0" date="2011-07-01" min="2.2" max="2.2.5">
+      - First release: Block login, Admin content page, ABF Facade/Singleton
+    </release>
+  </releases>
 </extension>

--- a/extensions/anti_brute_force/lang/lang.fr.php
+++ b/extensions/anti_brute_force/lang/lang.fr.php
@@ -1,161 +1,167 @@
 <?php
 
-    $about = array(
-        'name' => 'Français',
-        'author' => array(
-            'name' => 'Deux Huit Huit',
-            'email' => 'open-source (at) deuxhuithuit.com',
-            'website' => 'http://www.deuxhuithuit.com/'
-        ),
-        'release-date' => '2012-11-15',
-    );
+$about = array(
+    'name' => 'Français',
+    'author' => array(
+        'name' => 'Deux Huit Huit',
+        'email' => 'open-source (at) deuxhuithuit.com',
+        'website' => 'http://www.deuxhuithuit.com/'
+    ),
+    'release-date' => '2012-11-15',
+);
 
-    /**
-     * Save and return
-     */
-    $dictionary = array(
+/**
+* Save and return
+*/
+$dictionary = array(
 
-        'Anti Brute Force' =>
-        'Protection "Brute Force"',
+    'Anti Brute Force' =>
+    'Protection "Brute Force"',
 
-        'Secure your backend login page against brute force attacks' =>
-        'Sécurisez la page de connection contre les attaques "brute force"',
+    'Secure your backend login page against brute force attacks' =>
+    'Sécurisez la page de connection contre les attaques "brute force"',
 
-        'Define here when and how IP are blocked' =>
-        'Comment et pour combien de temps les IP sont bloquées',
+    'Define here when and how IP are blocked' =>
+    'Comment et pour combien de temps les IP sont bloquées',
 
-        'Fail count limit' =>
-        'Limite d\'erreurs',
+    'Fail count limit' =>
+    'Limite d\'erreurs',
 
-        'Blocked length <em>in minutes</em>' =>
-        'Durée d\'expulsion <em>minutes</em>',
+    'Blocked length <em>in minutes</em>' =>
+    'Durée d\'expulsion <em>minutes</em>',
 
-        '"%s" is not a valid positive integer' =>
-        '"%s" n\'est pas un entier positif',
+    '"%s" is not a valid positive integer' =>
+    '"%s" n\'est pas un entier positif',
 
-        'Your IP address is currently banned, due to typing too many wrong usernames/passwords.' =>
-        'Votre adresse IP est bannie pour avoir essayer trop de mauvais noms d\'usager et/ou mot de passes',
+    'Your IP address is currently banned, due to typing too many wrong usernames/passwords.' =>
+    'Votre adresse IP est bannie pour avoir essayer trop de mauvais noms d\'usager et/ou mot de passes',
 
-        'You can ask your administrator to unlock your account or wait %s minutes.' =>
-        'Demandez à votre administrateur de débloquer votre compte ou attendez %s minutes',
+    'You can ask your administrator to unlock your account or wait %s minutes.' =>
+    'Demandez à votre administrateur de débloquer votre compte ou attendez %s minutes',
 
-        'Banned IP address' =>
-        'Adresse IP bannie',
+    'Banned IP address' =>
+    'Adresse IP bannie',
 
-        'Banned IPs' =>
-        'Adresses IP bannies',
+    'Banned IPs' =>
+    'Adresses IP bannies',
 
-        'IP Address' =>
-        'Adresse IP',
+    'IP Address' =>
+    'Adresse IP',
 
-        'Raw IP value' =>
-        'Valeur IP lue',
+    'Raw IP value' =>
+    'Valeur IP lue',
 
-        'Last Attempt' =>
-        'Dernière tentative',
+    'Last Attempt' =>
+    'Dernière tentative',
 
-        'Failed Count' =>
-        'Nombre d\'échec',
+    'Failed Count' =>
+    'Nombre d\'échec',
 
-        'User Agent (browser)'=>
-        'User Agent (fureteur)',
+    'User Agent (browser)'=>
+    'User Agent (fureteur)',
 
-        'Username' =>
-        'Nom d\'usager',
+    'Username' =>
+    'Nom d\'usager',
 
-        'Failures remove successfuly' =>
-        'Échecs supprimés',
+    'Failures remove successfuly' =>
+    'Échecs supprimés',
 
-        'Source' =>
-        'Source',
+    'Source' =>
+    'Source',
 
-        'Enter your email address to be sent a remote unban link with further instructions.' =>
-        'Veuillez entrer votre adresse courriel pour recevoir un lien et des instruction pour vous ré-autoriser.',
+    'Check your inbox. ' =>
+    null,
 
-        'Email Address' =>
-        'Courriel',
+    'We have sent you an email. Follow the instruction in it.' =>
+    'Nous vous avons envoyé un e-mail. Veuillez suivre les instructions qui y figurent.',
 
-        'Users can unban their IP via email' =>
-        'Les utilisateurs peuvent se débannir via courriel',
+    'Enter your email address to be sent a remote unban link with further instructions.' =>
+    'Veuillez entrer votre adresse courriel pour recevoir un lien et des instruction pour vous ré-autoriser.',
 
-        'Alternatively, you can <a href="%s">un-ban your IP by email</a>.' =>
-        'De plus, vous pouvez vous <a href="%s">débannir par courriel</a>.',
+    'Email Address' =>
+    'Courriel',
 
-        'Please follow this link to unban your IP: ' =>
-        'Veuillez suivre ce lien pour vous débannir: ',
+    'Users can unban their IP via email' =>
+    'Les utilisateurs peuvent se débannir via courriel',
 
-        'If you do not remember your password, follow the "forgot password" link on the login page.' =>
-        'Si vous ne vous souvenez plus de votre mot de passe, veuillez suivre le lien "mot de passe oublié" sur la page d\'identification.',
+    'Alternatively, you can <a href="%s">un-ban your IP by email</a>.' =>
+    'De plus, vous pouvez vous <a href="%s">débannir par courriel</a>.',
 
-        'Gray list threshold' =>
-        'Limit de la liste grise',
+    'Please follow this link to unban your IP: ' =>
+    'Veuillez suivre ce lien pour vous débannir: ',
 
-        'Gray list duration <em>in days</em>' =>
-        'Durée de validité de la liste grise <em>en jour</em>',
+    'If you do not remember your password, follow the "forgot password" link on the login page.' =>
+    'Si vous ne vous souvenez plus de votre mot de passe, veuillez suivre le lien "mot de passe oublié" sur la page d\'identification.',
 
-        'Your IP address is currently <strong>black listed</strong>, due to too many bans.' =>
-        'Votre adresse IP est présentement <strong>sur la liste noire</strong>, dû à trop d\'erreurs.',
+    'Gray list threshold' =>
+    'Limit de la liste grise',
 
-        'Ask your administrator to unlock your IP.' =>
-        'Demandez à votre administrateur de débloquer votre adresse IP.',
+    'Gray list duration <em>in days</em>' =>
+    'Durée de validité de la liste grise <em>en jour</em>',
 
-        'Black listed IP address' =>
-        'Adresse IP sur la liste noire',
+    'Your IP address is currently <strong>black listed</strong>, due to too many bans.' =>
+    'Votre adresse IP est présentement <strong>sur la liste noire</strong>, dû à trop d\'erreurs.',
 
-        'Date Created' =>
-        'Date d\'ajout',
+    'Ask your administrator to unlock your IP.' =>
+    'Demandez à votre administrateur de débloquer votre adresse IP.',
 
-        'Entries remove successfuly' =>
-        'Entrées supprimées avec succès',
+    'Black listed IP address' =>
+    'Adresse IP sur la liste noire',
 
-        'Change' =>
-        'Changer',
+    'Date Created' =>
+    'Date d\'ajout',
 
-        'Black list' =>
-        'Liste noire',
+    'Entries remove successfuly' =>
+    'Entrées supprimées avec succès',
 
-        'Gray list' =>
-        'Liste grise',
+    'Change' =>
+    'Changer',
 
-        'White list' =>
-        'Liste blanche',
+    'Black list' =>
+    'Liste noire',
 
-        'Add' =>
-        'Ajouter',
+    'Gray list' =>
+    'Liste grise',
 
-        'IP added successfuly' =>
-        'Adresse IP ajoutée avec succès',
+    'White list' =>
+    'Liste blanche',
 
-        'Black Listed IPs' =>
-        'Liste noire d\'IP',
+    'Add' =>
+    'Ajouter',
 
-        'Gray Listed IPs' =>
-        'Liste grise d\'IP',
+    'IP added successfuly' =>
+    'Adresse IP ajoutée avec succès',
 
-        'White Listed IPs' =>
-        'Liste blanche d\'IP',
+    'Black Listed IPs' =>
+    'Liste noire d\'IP',
 
-        "%s is not installed properly and does not protect Symphony until this is fixed. Ensure latest version is installed." =>
-        "%s n'est pas installé correctement et ne protège Symphony si ceci n'est pas réglé. Assurez-vous d'avoir la dernière version d'installer.",
+    'Gray Listed IPs' =>
+    'Liste grise d\'IP',
 
-        'Unban via email' =>
-        'Déblocage par courriel',
+    'White Listed IPs' =>
+    'Liste blanche d\'IP',
 
-        'There are currently' =>
-        'Il y a présentement',
+    "%s is not installed properly and does not protect Symphony until this is fixed. Ensure latest version is installed." =>
+    "%s n'est pas installé correctement et ne protège Symphony si ceci n'est pas réglé. Assurez-vous d'avoir la dernière version d'installer.",
 
-        '%d blocked IPs.' =>
-        '%d adresses IP bloquées',
+    'Unban via email' =>
+    'Déblocage par courriel',
 
-        'Restrict access from authors' =>
-        'Restreindre l\'acces des auteurs',
+    'There are currently' =>
+    'Il y a présentement',
 
-        'Error: The given IP address, `%s`, is not valid' =>
-        "Erreur: L'adresse IP fournie, `%s`, n'est pas valide",
+    '%d blocked IPs.' =>
+    '%d adresses IP bloquées',
 
-        'Default Email Gateway is not configured. Unban via email may not work.' =>
-        "La passerelle de courriel par défaut n'est pas configurée. Les utilisateurs ne pourront pas de débannir par courriel.",
+    'Restrict access from authors' =>
+    'Restreindre l\'acces des auteurs',
 
-        'Go to the Preferences page to fix this.' =>
-        "Aller a la page des Préférences pour régler ceci"
-    );
+    'Error: The given IP address, `%s`, is not valid' =>
+    "Erreur: L'adresse IP fournie, `%s`, n'est pas valide",
+
+    'Default Email Gateway is not configured. Unban via email may not work.' =>
+    "La passerelle de courriel par défaut n'est pas configurée. Les utilisateurs ne pourront pas de débannir par courriel.",
+
+    'Go to the Preferences page to fix this.' =>
+    "Aller a la page des Préférences pour régler ceci"
+);

--- a/extensions/anti_brute_force/lang/lang.it.php
+++ b/extensions/anti_brute_force/lang/lang.it.php
@@ -1,153 +1,159 @@
 <?php
 
-  $about = array(
-		'name' => 'Italian',
-		'author' => array(
-			'name' => 'Davide Grobberio',
-			'email' => 'davide@zaniniadv.it',
-			'website' => 'http://www.zaniniadv.it/'
-		),
-		'release-date' => '2013-01-27',
-	);
+$about = array(
+    'name' => 'Italian',
+    'author' => array(
+        'name' => 'Davide Grobberio',
+        'email' => 'davide@zaniniadv.it',
+        'website' => 'http://www.zaniniadv.it/'
+    ),
+    'release-date' => '2013-01-27',
+);
 
-	/**
-	 * Italian translation for "Anti Brute Force" extension
-	 */
-	
-	$dictionary = array(
+/**
+ * Italian translation for "Anti Brute Force" extension
+ */
 
-		'Anti Brute Force' =>
-		'Anti "Brute Force"',
+$dictionary = array(
 
-		'Secure your backend login page against brute force attacks' =>
-		'Proteggi la sezione di amministrazione del tuo sito contro gli attacchi di "brute force" (forza bruta)',
+    'Anti Brute Force' =>
+    'Anti "Brute Force"',
 
-		'Define here when and how IP are blocked' =>
-		'Definisci qui quando e come gli IP sono bloccati',
+    'Secure your backend login page against brute force attacks' =>
+    'Proteggi la sezione di amministrazione del tuo sito contro gli attacchi di "brute force" (forza bruta)',
 
-		'Limite errori' =>
-		'Limite d\'erreurs',
+    'Define here when and how IP are blocked' =>
+    'Definisci qui quando e come gli IP sono bloccati',
 
-		'Blocked length <em>in minutes</em>' =>
-		'Blocco <em>in minuti</em>',
+    'Limite errori' =>
+    'Limite d\'erreurs',
 
-		'"%s" is not a valid positive integer' =>
-		'"%s" non è un numero intero positivo valido',
+    'Blocked length <em>in minutes</em>' =>
+    'Blocco <em>in minuti</em>',
 
-		'Your IP address is currently banned, due to typing too many wrong usernames/passwords.' =>
-		'Il tuo indirizzo IP è stato bloccato, causa troppe digitazioni (nome utente o password) sbagliate.',
+    '"%s" is not a valid positive integer' =>
+    '"%s" non è un numero intero positivo valido',
 
-		'You can ask your administrator to unlock your account or wait %s minutes.' =>
-		'Potete contattare il vostro amministratore per sbloccare l\'account, oppure attendete %s minuti.',
+    'Your IP address is currently banned, due to typing too many wrong usernames/passwords.' =>
+    'Il tuo indirizzo IP è stato bloccato, causa troppe digitazioni (nome utente o password) sbagliate.',
 
-		'Banned IP address' =>
-		'Indirizzo IP bannato',
+    'You can ask your administrator to unlock your account or wait %s minutes.' =>
+    'Potete contattare il vostro amministratore per sbloccare l\'account, oppure attendete %s minuti.',
 
-		'Banned IPs' =>
-		'Indirizzi IP bannati',
+    'Banned IP address' =>
+    'Indirizzo IP bannato',
 
-		'IP Address' =>
-		'Indirizzo IP',
-		
-		'Raw IP value' =>
-		null,
+    'Banned IPs' =>
+    'Indirizzi IP bannati',
 
-		'Last Attempt' =>
-		'Ultimo tentativo',
+    'IP Address' =>
+    'Indirizzo IP',
 
-		'Failed Count' =>
-		'Conta non riuscita',
+    'Raw IP value' =>
+    null,
 
-		'User Agent (browser)'=>
-		'User Agent (browser)',
+    'Last Attempt' =>
+    'Ultimo tentativo',
 
-		'Username' =>
-		'Utente',
+    'Failed Count' =>
+    'Conta non riuscita',
 
-		'Failures remove successfuly' =>
-		'Rimossione avvenuta con successo',
+    'User Agent (browser)'=>
+    'User Agent (browser)',
 
-		'Source' =>
-		'Sorgente',
+    'Username' =>
+    'Utente',
 
-		'Enter your email address to be sent a remote unban link with further instructions.' =>
-		'Inserisci l\' indirizzo e-mail cui inviare un collegamento non bloccato con ulteriori istruzioni.',
+    'Failures remove successfuly' =>
+    'Rimossione avvenuta con successo',
 
-		'Email Address' =>
-		'Indirizzo email',
+    'Source' =>
+    'Sorgente',
 
-		'Users can unban their IP via email' =>
-		'Gli utenti possono sbloccare il loro indirizzo IP tramite email',
+    'Check your inbox. ' =>
+    null,
 
-		'Alternatively, you can <a href="%s">un-ban your IP by email</a>.' =>
-		'Altrimenti, puoi <a href="%s">sbloccare il tuo indirizzo tramite email</a>.',
+    'We have sent you an email. Follow the instruction in it.' =>
+    'Ti abbiamo inviato un\'e-mail. Segui le istruzioni riportate al suo interno.',
 
-		'Please follow this link to unban your IP: ' =>
-		'Segui questo link per sbloccare il tuo IP: ',
+    'Enter your email address to be sent a remote unban link with further instructions.' =>
+    'Inserisci l\' indirizzo e-mail cui inviare un collegamento non bloccato con ulteriori istruzioni.',
 
-		'If you do not remember your password, follow the "forgot password" link on the login page.' =>
-		'Se non ricordi la password, segui il link "recupera password" alla pagina di login.',
+    'Email Address' =>
+    'Indirizzo email',
 
-		'Gray list threshold' =>
-		'Soglia lista grigia',
+    'Users can unban their IP via email' =>
+    'Gli utenti possono sbloccare il loro indirizzo IP tramite email',
 
-		'Gray list duration <em>in days</em>' =>
-		'Durata lista grigia<em>in giorni</em>',
+    'Alternatively, you can <a href="%s">un-ban your IP by email</a>.' =>
+    'Altrimenti, puoi <a href="%s">sbloccare il tuo indirizzo tramite email</a>.',
 
-		'Your IP address is currently <strong>black listed</strong>, due to too many bans.' =>
-		'Il tuo indirizzo IP è attualmente <strong>bloccato</strong>, causa troppi sbagli.',
+    'Please follow this link to unban your IP: ' =>
+    'Segui questo link per sbloccare il tuo IP: ',
 
-		'Ask your administrator to unlock your IP.' =>
-		'Chiedi al tuo amministratore di sbloccare il tuo indirizzo IP.',
+    'If you do not remember your password, follow the "forgot password" link on the login page.' =>
+    'Se non ricordi la password, segui il link "recupera password" alla pagina di login.',
 
-		'Black listed IP address' =>
-		'Lista nera indirizzi IP',
+    'Gray list threshold' =>
+    'Soglia lista grigia',
 
-		'Date Created' =>
-		'Data di creazione',
+    'Gray list duration <em>in days</em>' =>
+    'Durata lista grigia<em>in giorni</em>',
 
-		'Entries remove successfuly' =>
-		'Voci rimosse con successo',
+    'Your IP address is currently <strong>black listed</strong>, due to too many bans.' =>
+    'Il tuo indirizzo IP è attualmente <strong>bloccato</strong>, causa troppi sbagli.',
 
-		'Change' =>
-		'Modifica',
+    'Ask your administrator to unlock your IP.' =>
+    'Chiedi al tuo amministratore di sbloccare il tuo indirizzo IP.',
 
-		'Black list' =>
-		'Lista nera',
+    'Black listed IP address' =>
+    'Lista nera indirizzi IP',
 
-		'Gray list' =>
-		'Lista grigia',
+    'Date Created' =>
+    'Data di creazione',
 
-		'White list' =>
-		'Lista bianca',
+    'Entries remove successfuly' =>
+    'Voci rimosse con successo',
 
-		'Add' =>
-		'Aggiungi',
+    'Change' =>
+    'Modifica',
 
-		'IP added successfuly' =>
-		'IP aggiunto con successo',
+    'Black list' =>
+    'Lista nera',
 
-		'Black Listed IPs' =>
-		'IP lista nera',
+    'Gray list' =>
+    'Lista grigia',
 
-		'Gray Listed IPs' =>
-		'IP lista grigia',
+    'White list' =>
+    'Lista bianca',
 
-		'White Listed IPs' =>
-		'IP lista bianca',
+    'Add' =>
+    'Aggiungi',
 
-		"%s is not installed properly and does not protect Symphony until this is fixed. Ensure latest version is installed." =>
-		"%s non è installato correttamente e non proteggerà Symphony fino a quando questo non sarà risolto. Assicurarsi di aver installato l'ultima versione.",
+    'IP added successfuly' =>
+    'IP aggiunto con successo',
 
-		'Unban via email' =>
-		'Sblocca via email',
+    'Black Listed IPs' =>
+    'IP lista nera',
 
-		'There are currently' =>
-		'Ci sono attualmente',
+    'Gray Listed IPs' =>
+    'IP lista grigia',
 
-		'%d blocked IPs.' =>
-		'%d indirizzi IP bloccati',
+    'White Listed IPs' =>
+    'IP lista bianca',
 
-		'Restrict access from authors' =>
-		'Limitare l\'accesso agli autori',
-	);
+    "%s is not installed properly and does not protect Symphony until this is fixed. Ensure latest version is installed." =>
+    "%s non è installato correttamente e non proteggerà Symphony fino a quando questo non sarà risolto. Assicurarsi di aver installato l'ultima versione.",
+
+    'Unban via email' =>
+    'Sblocca via email',
+
+    'There are currently' =>
+    'Ci sono attualmente',
+
+    '%d blocked IPs.' =>
+    '%d indirizzi IP bloccati',
+
+    'Restrict access from authors' =>
+    'Limitare l\'accesso agli autori',
+);

--- a/extensions/anti_brute_force/lang/lang.ru.php
+++ b/extensions/anti_brute_force/lang/lang.ru.php
@@ -45,8 +45,11 @@ $dictionary = array(
     'Define here when and how IP are blocked' =>
     'Определите когда и как блокировать IP адреса',
 
-    'Email sent. Follow the instruction in it.' =>
-    'Письмо отправлено. Следуйте дальнейшим инструкциям.',
+    'Check your inbox. ' =>
+    null,
+
+    'We have sent you an email. Follow the instruction in it.' =>
+    'Мы отправили вам электронное письмо. Следуйте инструкциям, указанным в нем.',
 
     'Enter your email address to be sent a remote unban link with further instructions.' =>
     'Укажите ваш email для отправки сообщения с ссылкой и инструкцией для дальнейшей разблокировки.',

--- a/extensions/anti_brute_force/lib/class.ABF.php
+++ b/extensions/anti_brute_force/lib/class.ABF.php
@@ -176,12 +176,18 @@ class ABF implements Singleton
 
                 // check if blacklisted
                 if ($this->isBlackListed()) {
+                    // discard form data
+                    $_POST = array();
+
                     // block access
                     $this->throwBlackListedException();
                 }
 
                 // check if banned
                 if ($this->isCurrentlyBanned()) {
+                    // discard form data
+                    $_POST = array();
+
                     // block access
                     $this->throwBannedException();
                 }
@@ -291,12 +297,17 @@ class ABF implements Singleton
             . '<br/><br/>' .
             __('You can ask your administrator to unlock your account or wait %s minutes.', array($length));
 
-        if ($useUnbanViaEmail == 'on') {
+        if ($useUnbanViaEmail === 'on') {
             $msg .= ('<br/><br/>' . __('Alternatively, you can <a href="%s">un-ban your IP by email</a>.', array(SYMPHONY_URL . self::UNBAND_LINK)));
         }
 
+        // Backward compatibility with Sym8 ≤ 2.85.1 and Symphony ≤ 2.7.10
+        $status = defined('Page::HTTP_STATUS_TOO_MANY_REQUESTS')
+                    ? Page::HTTP_STATUS_TOO_MANY_REQUESTS
+                    : Page::HTTP_STATUS_FORBIDDEN;
+
         // banned - throw exception
-        throw new SymphonyErrorPage($msg, __('Banned IP address'));
+        throw new SymphonyErrorPage($msg, __('Banned IP address'), 'generic', array(), $status);
     }
 
     /**
@@ -391,7 +402,8 @@ class ABF implements Singleton
         $ret = false;
 
         // do not re-register existing entries
-        if ($results != null && count($results) > 0) {
+        #if ($results !== null && count($results) > 0) {
+        if ($results !== null && $results === true) {
             if ($isGray) {
                 $ret = $this->incrementGrayList($ip);
             }
@@ -492,7 +504,7 @@ class ABF implements Singleton
             __('Ask your administrator to unlock your IP.');
 
         // banned - throw exception
-        throw new SymphonyErrorPage($msg, __('Black listed IP address'));
+        throw new SymphonyErrorPage($msg, __('Black listed IP address'), 'generic', array(), Page::HTTP_STATUS_FORBIDDEN);
     }
 
 


### PR DESCRIPTION
- Prevent global ban check on login and unban flow
- The structure of screen messages has been adapted to the new structure
- POST data is discarded only for blocked requests
- The cron job has been updated
- The structure of the "Unban IP link" message has been updated
- Fix: If no "From" email address defined, no unban email is sent
- Improved: HTTP status codes vor banned and blacklisted error pages
- Update the README file and the license