### PR TITLE
Fix: Display missing extension error page correctly

### DIFF
--- a/symphony/lib/toolkit/class.extensionmanager.php
+++ b/symphony/lib/toolkit/class.extensionmanager.php
@@ -1035,20 +1035,16 @@ class ExtensionManager implements FileResource
                     '<code>' . $name . '</code>',
                     '<code>' . str_replace(DOCROOT . '/', '', $path) . '</code>'
                 ));
-                try {
-                    Symphony::Engine()->throwCustomError(
+                throw new SymphonyErrorPage(
                         $errMsg,
                         __('Symphony Extension Missing Error'),
-                        Page::HTTP_STATUS_ERROR,
                         'missing_extension',
                         array(
                             'name' => $name,
                             'path' => $path
-                        )
-                    );
-                } catch (Exception $ex) {
-                    throw new Exception($errMsg, 0, $ex);
-                }
+                        ),
+                        Page::HTTP_STATUS_ERROR
+                );
             }
 
             if (!class_exists($classname)) {


### PR DESCRIPTION
Replace the ineffective `try`/`catch` block with a direct SymphonyErrorPage exception to ensure missing extensions are reported using the intended error template.