### PR TITLE
Modernize all Symphony error templates with Pico CSS

### DIFF
--- a/symphony/assets/css/pico-error.css
+++ b/symphony/assets/css/pico-error.css
@@ -1,0 +1,147 @@
+/*!
+ * Sym8
+ * https://sym8.io
+ * @author: tiloschroeder
+ * Copyright (c) 2026
+ * License MIT
+ */
+:root {
+  --pico-tile-background-color: #eff1f4;
+}
+[data-theme="dark"] {
+  --pico-tile-background-color: #2a3140;
+}
+.container h1 {
+  font-weight: 500;
+  text-align: center;
+}
+
+.errorpage {
+  margin: 0 auto;
+  max-width: 480px;
+  padding-top: 5%;
+}
+.template-generic .errorpage {
+  max-width: 560px;
+}
+.frame {
+  padding-top: calc(2 * var(--pico-block-spacing-vertical));
+}
+.inner {
+  background-color: var(--pico-tile-background-color);
+  border-radius: var(--pico-border-radius);
+  padding: var(--pico-spacing);
+}
+.inner h2 {
+  font-size: 26px;
+  font-weight: 500;
+  margin-bottom: calc(1.5 * var(--pico-spacing));
+}
+.inner code {
+  word-break: break-word;
+}
+.back-to-website {
+  margin: calc(3 * var(--pico-spacing)) 0;
+}
+.back-link {
+  /*padding-inline-start: var(--pico-spacing);*/
+}
+.back-link:before {
+  content: '\2190  ';
+  text-decoration: none;
+}
+:dir(rtl) .back-link:before {
+  content: '\2192  ';
+}
+details .summary-button {
+  --pico-background-color: transparent;
+  --pico-color: var(--pico-primary);
+  --pico-border-color: var(--pico-primary);
+  --pico-box-shadow: var(--pico-button-hover-box-shadow, 0 0 0 rgba(0, 0, 0, 0)), 0 0 0 var(--pico-outline-width) var(--pico-primary-focus);
+  --pico-background-color: var(--pico-primary-background);
+  --pico-border-color: var(--pico-primary-border);
+  --pico-box-shadow: var(--pico-button-box-shadow, 0 0 0 rgba(0, 0, 0, 0));
+  padding: var(--pico-form-element-spacing-vertical) var(--pico-form-element-spacing-horizontal);
+  border: var(--pico-border-width) solid var(--pico-border-color);
+  border-radius: var(--pico-border-radius);
+  outline: 0;
+  background-color: transparent;
+  box-shadow: var(--pico-box-shadow);
+  color: var(--pico-color)!important;
+  font-weight: var(--pico-font-weight);
+  font-size: calc(1rem * 1.2);
+  text-decoration: none;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+  transition: background-color var(--pico-transition), border-color var(--pico-transition), color var(--pico-transition), box-shadow var(--pico-transition);
+}
+details .summary-button:active,
+details .summary-button:focus,
+details .summary-button:hover {
+  --pico-box-shadow: var(--pico-button-hover-box-shadow, 0 0 0 rgba(0, 0, 0, 0)), 0 0 0 var(--pico-outline-width) var(--pico-primary-focus);
+  --pico-background-color: transparent;
+  --pico-color: var(--pico-primary-hover);
+  --pico-border-color: var(--pico-primary-hover-border);
+}
+.error-log {
+  padding-inline-start: calc(var(--pico-spacing) / 2);
+  padding-inline-end: calc(var(--pico-spacing) / 2);
+}
+.error-log li {
+  align-items: stretch;
+  border: 1px solid var(--pico-code-background-color);
+  display: flex;
+  flex-direction: row;
+  list-style: none;
+  margin-bottom: 0;
+}
+.error-log li:first-child {
+  border-top-left-radius: var(--pico-border-radius);
+  border-top-right-radius: var(--pico-border-radius);
+}
+.error-log li:last-child {
+  border-bottom-left-radius: var(--pico-border-radius);
+  border-bottom-right-radius: var(--pico-border-radius);
+}
+.error-log strong {
+  background-color: var(--pico-code-background-color);
+  color: var(--pico-secondary);
+  font-weight: 500;
+  padding-inline-start: var(--pico-spacing);
+  padding-inline-end: var(--pico-spacing);
+}
+.error-log code {
+  border-radius: 0;
+  flex: 1;
+  white-space: pre-wrap;
+}
+@media only screen and (prefers-color-scheme: dark) {
+  :root {
+    --pico-tile-background-color: #2a3140;
+  }
+  [data-theme="light"] {
+    --pico-tile-background-color: #eff1f4;
+  }
+}
+@media screen and (min-width: 576px) {
+  :root {
+    --pico-font-size: 100%;
+  }
+}
+@media (min-width: 768px) {
+  :root {
+    --pico-font-size: 100%;
+  }
+}
+@media (min-width: 1024px) {
+  :root {
+    --pico-font-size: 100%;
+  }
+}
+@media (min-width: 1280px) {
+  :root {
+    --pico-font-size: 100%;
+  }
+}

--- a/symphony/assets/js/usererror-generic.js
+++ b/symphony/assets/js/usererror-generic.js
@@ -1,0 +1,23 @@
+/*!
+ * Sym8
+ * https://sym8.io
+ * @author: tiloschroeder
+ * Copyright (c) 2026
+ * License MIT
+ */
+function init(o) {
+  "loading" !== document.readyState
+  ? o()
+  : document.addEventListener
+  ? document.addEventListener("DOMContentLoaded", o)
+  : document.attachEvent("onreadystatechange", function () {
+    "complete" === document.readyState && o();
+  });
+}
+
+init(function () {
+  // prevent re-submitting a form via reload
+  if (window.history.replaceState) {
+    window.history.replaceState(null, "", window.location.href);
+  }
+});

--- a/symphony/template/fatalerror.database.tpl
+++ b/symphony/template/fatalerror.database.tpl
@@ -1,38 +1,32 @@
 <!DOCTYPE html>
-<html lang="en" dir="ltr">
+<html lang="en" dir="ltr" data-type="database-tpl">
   <head>
     <meta charset="utf-8">
+    <meta name="robots" content="noindex">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="dark light">
     <title>Symphony Error</title>
-    <link media="screen" href="{ASSETS_URL}/css/symphony.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{ASSETS_URL}/css/pico.min.css?v={VERSION}">
+    <link rel="stylesheet" href="{ASSETS_URL}/css/pico-error.css?v={VERSION}">
+    <link rel="stylesheet" href="{ASSETS_URL}/css/pico-messages.css?v={VERSION}">
     <script src="{ASSETS_URL}/js/symphony.min.js"></script>
     <script>Symphony.Context.add('root', '{URL}');Symphony.Context.add('env', {});</script>
   </head>
   <body id="error">
-    <div class="frame">
-      <ul>
-        <li>
-          <h1><em>Symphony Fatal Database Error:</em> %s</h1>
+    <main class="container errorpage">
+      <h1>Symphony</h1>
+      <div class="frame">
+        <div class="inner">
+          <h2>Symphony Fatal Database Error</h2>
+          <p class="message invalid"><code>%s</code></p>
           <p>An error occurred while attempting to execute the following query</p>
           <ul>
             <li class="error full">
               <code>%s</code>
             </li>
           </ul>
-        </li>
-        <li>
-          <header class="frame-header">Backtrace</header>
-          <div class="content">
-            <ul>%s</ul>
-          </div>
-        </li>
-        <li>
-          <header class="frame-header">Database Query Log</header>
-          <div class="content">
-            <ul>%s</ul>
-          </div>
-        </li>
-      </ul>
-    </div>
+        </div>
+      </div>
+    </main>
   </body>
 </html>

--- a/symphony/template/fatalerror.fatal.tpl
+++ b/symphony/template/fatalerror.fatal.tpl
@@ -1,21 +1,27 @@
 <!DOCTYPE html>
-<html lang="en" dir="ltr">
+<html lang="en" dir="ltr" data-type="fatal-tpl">
   <head>
     <meta charset="utf-8">
+    <meta name="robots" content="noindex">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="dark light">
     <title>Symphony Error</title>
-    <link media="screen" href="{ASSETS_URL}/css/symphony.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{ASSETS_URL}/css/pico.min.css?v={VERSION}">
+    <link rel="stylesheet" href="{ASSETS_URL}/css/pico-error.css?v={VERSION}">
+    <link rel="stylesheet" href="{ASSETS_URL}/css/pico-messages.css?v={VERSION}">
     <script src="{ASSETS_URL}/js/symphony.min.js"></script>
     <script>Symphony.Context.add('root', '{URL}');Symphony.Context.add('env', {});</script>
   </head>
-  <body id="error">
-    <div class="frame">
-      <ul>
-        <li>
-          <h1><em>Symphony %s:</em> %s</h1>
+  <body id="error" class="template-generic">
+    <main class="container errorpage">
+      <h1>Symphony</h1>
+      <div class="frame">
+        <div class="inner">
+          <h2>Symphony %s</h2>
+          <p><code>%s</code></p>
           <p>An error occurred in <code>%s</code> around line <code>%d</code></p>
-        </li>
-      </ul>
-    </div>
+        </div>
+      </div>
+    </main>
   </body>
 </html>

--- a/symphony/template/fatalerror.generic.tpl
+++ b/symphony/template/fatalerror.generic.tpl
@@ -1,34 +1,33 @@
 <!DOCTYPE html>
-<html lang="en" dir="ltr">
+<html lang="en" dir="ltr" data-type="generic-tpl">
   <head>
     <meta charset="utf-8">
+    <meta name="robots" content="noindex">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="dark light">
     <title>Symphony Error</title>
-    <link media="screen" href="{ASSETS_URL}/css/symphony.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{ASSETS_URL}/css/pico.min.css?v={VERSION}">
+    <link rel="stylesheet" href="{ASSETS_URL}/css/pico-error.css?v={VERSION}">
+    <link rel="stylesheet" href="{ASSETS_URL}/css/pico-messages.css?v={VERSION}">
     <script src="{ASSETS_URL}/js/symphony.min.js"></script>
     <script>Symphony.Context.add('root', '{URL}');Symphony.Context.add('env', {});</script>
   </head>
-  <body id="error">
-    <div class="frame">
-      <ul>
-        <li>
-          <h1><em>Symphony %s:</em> %s</h1>
+  <body id="error" class="template-generic">
+    <main class="container errorpage">
+      <h1>Symphony</h1>
+      <div class="frame">
+        <div class="inner">
+          <h2>%s</h2>
+          <p><code>%s</code></p>
           <p>An error occurred in <code>%s</code> around line <code>%d</code></p>
-          <ul>%s</ul>
-        </li>
-        <li>
-          <header class="frame-header">Backtrace</header>
-          <div class="content">
-            <ul>%s</ul>
-          </div>
-        </li>
-        <li>
-          <header class="frame-header">Database Query Log</header>
-          <div class="content">
-            <ul>%s</ul>
-          </div>
-        </li>
-      </ul>
-    </div>
+          <!-- error -->
+          %s
+          <!-- backtrace -->
+          %s
+          <!-- queries -->
+          %s
+        </div>
+      </div>
+    </main>
   </body>
 </html>

--- a/symphony/template/fatalerror.rewrite.tpl
+++ b/symphony/template/fatalerror.rewrite.tpl
@@ -1,21 +1,27 @@
 <!DOCTYPE html>
-<html lang="en" dir="ltr">
+<html lang="en" dir="ltr" data-type="rewrite-tpl">
   <head>
     <meta charset="utf-8">
+    <meta name="robots" content="noindex">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="dark light">
     <title>Symphony Error</title>
-    <link media="screen" href="{ASSETS_URL}/css/symphony.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{ASSETS_URL}/css/pico.min.css?v={VERSION}">
+    <link rel="stylesheet" href="{ASSETS_URL}/css/pico-error.css?v={VERSION}">
+    <link rel="stylesheet" href="{ASSETS_URL}/css/pico-messages.css?v={VERSION}">
     <script src="{ASSETS_URL}/js/symphony.min.js"></script>
     <script>Symphony.Context.add('root', '{URL}');Symphony.Context.add('env', {});</script>
   </head>
   <body id="error">
-    <div class="frame">
-      <ul>
-        <li>
-          <h1><em>Symphony Error:</em> <code>mod_rewrite</code> is not enabled</h1>
+    <main class="container errorpage">
+      <h1>Symphony</h1>
+      <div class="frame">
+        <div class="inner">
+          <h2>Symphony Error</h2>
+          <p class="message invalid">Module <code>mod_rewrite</code> is not enabled.</p>
           <p>It appears the <code>mod_rewrite</code> is not enabled or available on this server.</p>
-        </li>
-      </ul>
-    </div>
+        </div>
+      </div>
+    </main>
   </body>
 </html>

--- a/symphony/template/usererror.database.php
+++ b/symphony/template/usererror.database.php
@@ -6,10 +6,15 @@ $Page->Html->setElementStyle('html');
 
 $Page->Html->setDTD('<!DOCTYPE html>');
 $Page->Html->setAttribute('lang', 'en');
-#$Page->addElementToHead(new XMLElement('meta', null, array('http-equiv' => 'Content-Type', 'content' => 'text/html; charset=UTF-8')), 0);
+$Page->Html->setAttribute('dir', 'ltr');
+$Page->Html->setAttribute('data-type', 'database');
 $Page->addElementToHead(new XMLElement('meta', null, array('charset' => 'UTF-8')), 0);
-$Page->addElementToHead(new XMLElement('meta', null, array('name' => 'viewport', 'content' => 'width=device-width, initial-scale=1')), 1);
-$Page->addStylesheetToHead(ASSETS_URL . '/css/symphony.min.css', 'screen', null, false);
+$Page->addElementToHead(new XMLElement('meta', null, array('name' => 'robots', 'content' => 'noindex')), 1);
+$Page->addElementToHead(new XMLElement('meta', null, array('name' => 'viewport', 'content' => 'width=device-width, initial-scale=1')), 2);
+$Page->addElementToHead(new XMLElement('meta', null, array('name' => 'color-scheme', 'content' => 'dark light')), 3);
+$Page->addStylesheetToHead(ASSETS_URL . '/css/pico.min.css', 'screen', null, false, true);
+$Page->addStylesheetToHead(ASSETS_URL . '/css/pico-error.css', 'screen', null, false, true);
+$Page->addStylesheetToHead(ASSETS_URL . '/css/pico-messages.css', 'screen', null, false, true);
 
 $Page->setHttpStatus($e->getHttpStatusCode());
 $Page->addHeaderToPage('Content-Type', 'text/html; charset=UTF-8');
@@ -22,18 +27,25 @@ if (isset($e->getAdditional()->header)) {
 $Page->setTitle(__('%1$s &ndash; %2$s', array(__('Symphony'), __('Database Error'))));
 $Page->Body->setAttribute('id', 'error');
 
+$main = new XMLElement('main', null, array('class' => 'container errorpage'));
+$main->appendChild(new XMLElement('h1', __('Symphony')));
+
 $div = new XMLElement('div', null, array('class' => 'frame'));
-$div->appendChild(new XMLElement('h1', __('Symphony Database Error')));
-$div->appendChild(new XMLElement('p', $e->getAdditional()->message));
-$div->appendChild(new XMLElement('p', '<code>'.$e->getAdditional()->error->getDatabaseErrorCode().': '.$e->getAdditional()->error->getDatabaseErrorMessage().'</code>'));
+$divInner = new XMLElement('div', null, array('class' => 'inner'));
+$divInner->appendChild(new XMLElement('h2', __('Database Error')));
+$divInner->appendChild(new XMLElement('p', $e->getAdditional()->message));
+$divInner->appendChild(new XMLElement('p', '<code>'.$e->getAdditional()->error->getDatabaseErrorCode().': '.$e->getAdditional()->error->getDatabaseErrorMessage().'</code>'));
 
 $query = $e->getAdditional()->error->getQuery();
 
 if (isset($query)) {
-    $div->appendChild(new XMLElement('p', '<code>'.$e->getAdditional()->error->getQuery().'</code>'));
+    $divInner->appendChild(new XMLElement('p', '<code>'.$e->getAdditional()->error->getQuery().'</code>'));
 }
+$div->appendChild($divInner);
 
-$Page->Body->appendChild($div);
+$main->appendChild($div);
+
+$Page->Body->appendChild($main);
 
 $output = $Page->generate();
 echo $output;

--- a/symphony/template/usererror.generic.php
+++ b/symphony/template/usererror.generic.php
@@ -6,10 +6,17 @@ $Page->Html->setElementStyle('html');
 
 $Page->Html->setDTD('<!DOCTYPE html>');
 $Page->Html->setAttribute('lang', 'en');
-#$Page->addElementToHead(new XMLElement('meta', null, array('http-equiv' => 'Content-Type', 'content' => 'text/html; charset=UTF-8')), 0);
+$Page->Html->setAttribute('dir', 'ltr');
+$Page->Html->setAttribute('data-type', 'generic');
+// Enable for testing
+// $Page->Html->setAttribute('data-theme', 'light');
 $Page->addElementToHead(new XMLElement('meta', null, array('charset' => 'UTF-8')), 0);
-$Page->addElementToHead(new XMLElement('meta', null, array('name' => 'viewport', 'content' => 'width=device-width, initial-scale=1')), 1);
-$Page->addStylesheetToHead(ASSETS_URL . '/css/symphony.min.css', 'screen', null, false);
+$Page->addElementToHead(new XMLElement('meta', null, array('name' => 'robots', 'content' => 'noindex')), 1);
+$Page->addElementToHead(new XMLElement('meta', null, array('name' => 'viewport', 'content' => 'width=device-width, initial-scale=1')), 2);
+$Page->addElementToHead(new XMLElement('meta', null, array('name' => 'color-scheme', 'content' => 'dark light')), 3);
+$Page->addStylesheetToHead(ASSETS_URL . '/css/pico.min.css', 'screen', null, false, true);
+$Page->addStylesheetToHead(ASSETS_URL . '/css/pico-error.css', 'screen', null, false, true);
+$Page->addStylesheetToHead(ASSETS_URL . '/css/pico-messages.css', 'screen', null, false, true);
 
 $Page->setHttpStatus($e->getHttpStatusCode());
 $Page->addHeaderToPage('Content-Type', 'text/html; charset=UTF-8');
@@ -22,12 +29,19 @@ if (isset($e->getAdditional()->header)) {
 $Page->setTitle(__('%1$s &ndash; %2$s', array(__('Symphony'), $e->getHeading())));
 $Page->Body->setAttribute('id', 'error');
 
+$main = new XMLElement('main', null, array('class' => 'container errorpage'));
+$main->appendChild(new XMLElement('h1', __('Symphony')));
 $div = new XMLElement('div', null, array('class' => 'frame'));
-$div->appendChild(new XMLElement('h1', $e->getHeading()));
-$div->appendChild(
-    ($e->getMessageObject() instanceof XMLElement ? $e->getMessageObject() : new XMLElement('p', trim($e->getMessage())))
+$divInner = new XMLElement('div', null, array('class' => 'inner'));
+$divInner->appendChild(new XMLElement('h2', $e->getHeading()));
+$divInner->appendChild(
+    ($e->getMessageObject() instanceof XMLElement ? $e->getMessageObject() : new XMLElement('p', trim($e->getMessage()), array('class' => 'message invalid')))
 );
-$Page->Body->appendChild($div);
+$div->appendChild($divInner);
+
+$main->appendChild($div);
+
+$Page->Body->appendChild($main);
 
 $output = $Page->generate();
 echo $output;

--- a/symphony/template/usererror.missing_extension.php
+++ b/symphony/template/usererror.missing_extension.php
@@ -51,16 +51,23 @@ if (isset($_POST['extension-missing'])) {
     }
 }
 
+$author = Symphony::Author();
+
 $Page = new HTMLPage();
 
 $Page->Html->setElementStyle('html');
 
 $Page->Html->setDTD('<!DOCTYPE html>');
 $Page->Html->setAttribute('lang', 'en');
-#$Page->addElementToHead(new XMLElement('meta', null, array('http-equiv' => 'Content-Type', 'content' => 'text/html; charset=UTF-8')), 0);
+$Page->Html->setAttribute('dir', 'ltr');
+$Page->Html->setAttribute('data-type', 'extension');
 $Page->addElementToHead(new XMLElement('meta', null, array('charset' => 'UTF-8')), 0);
-$Page->addElementToHead(new XMLElement('meta', null, array('name' => 'viewport', 'content' => 'width=device-width, initial-scale=1')), 1);
-$Page->addStylesheetToHead(ASSETS_URL . '/css/symphony.min.css', 'screen', null, false);
+$Page->addElementToHead(new XMLElement('meta', null, array('name' => 'robots', 'content' => 'noindex')), 1);
+$Page->addElementToHead(new XMLElement('meta', null, array('name' => 'viewport', 'content' => 'width=device-width, initial-scale=1')), 2);
+$Page->addElementToHead(new XMLElement('meta', null, array('name' => 'color-scheme', 'content' => 'dark light')), 3);
+$Page->addStylesheetToHead(ASSETS_URL . '/css/pico.min.css', 'screen', null, false, true);
+$Page->addStylesheetToHead(ASSETS_URL . '/css/pico-error.css', 'screen', null, false, true);
+$Page->addStylesheetToHead(ASSETS_URL . '/css/pico-messages.css', 'screen', null, false, true);
 
 $Page->setHttpStatus($e->getHttpStatusCode());
 $Page->addHeaderToPage('Content-Type', 'text/html; charset=UTF-8');
@@ -69,11 +76,21 @@ $Page->addHeaderToPage('Symphony-Error-Type', 'missing-extension');
 $Page->setTitle(__('%1$s &ndash; %2$s', array(__('Symphony'), $e->getHeading())));
 $Page->Body->setAttribute('id', 'error');
 
+$main = new XMLElement('main', null, array('class' => 'container errorpage'));
+$main->appendChild(new XMLElement('h1', __('Symphony')));
+
 $div = new XMLElement('div', null, array('class' => 'frame'));
-$div->appendChild(new XMLElement('h1', $e->getHeading()));
-$div->appendChild(
-    new XMLElement('p', trim($e->getMessage()))
-);
+$divInner = new XMLElement('div', null, array('class' => 'inner'));
+$divInner->appendChild(new XMLElement('h2', $e->getHeading()));
+if ($author === null) {
+    $divInner->appendChild(
+        new XMLElement('p', __('A required Symphony extension could not be loaded.<br>Please contact the site administrator.'), array('class' => 'message invalid'))
+    );
+} elseif ($author !== null) {
+    $divInner->appendChild(
+        new XMLElement('p', trim($e->getMessage()), array('class' => 'message invalid'))
+    );
+}
 
 // Build the form, what it can do is yet to be determined
 $form = new XMLElement('form', null, array('action' => SYMPHONY_URL. '/system/extensions/', 'method' => 'post'));
@@ -92,46 +109,67 @@ $actions->appendChild(Widget::Input('action[delete]', __('Uninstall extension'),
 
 $form->appendChild($actions);
 
-// if the renamed failed
-if ($match != "" && $rename_failed) {
-    $div->appendChild(
-        new XMLElement('p', __('Sorry, but Symphony was unable to rename the folder. You can try renaming %s to %s yourself, or you can uninstall the extension to continue.', array(
-            '<code>extensions/' . General::sanitize($match) . '</code>',
-            '<code>extensions/' . General::sanitize($e->getAdditional()->name) . '</code>'
-        )))
-    );
-}
-// If we've found a similar folder
-elseif ($match != "") {
-    $div->appendChild(
-        new XMLElement('p', __('Often the cause of this error is a misnamed extension folder. You can try renaming %s to %s, or you can uninstall the extension to continue.', array(
-            '<code>extensions/' . $match . '</code>',
-            '<code>extensions/' . $e->getAdditional()->name . '</code>'
-        )))
-    );
+if ($author !== null) {
+    // if the renamed failed
+    if ($match != "" && $rename_failed) {
+        $divInner->appendChild(
+            new XMLElement('p', __('Sorry, but Symphony was unable to rename the folder. You can try renaming %s to %s yourself, or you can uninstall the extension to continue.', array(
+                '<code>extensions/' . General::sanitize($match) . '</code>',
+                '<code>extensions/' . General::sanitize($e->getAdditional()->name) . '</code>'
+            )), array('class' => 'message invalid'))
+        );
+    }
+    // If we've found a similar folder
+    elseif ($match != "") {
+        $divInner->appendChild(
+            new XMLElement('p', __('Often the cause of this error is a misnamed extension folder. You can try renaming %s to %s, or you can uninstall the extension to continue.', array(
+                '<code>extensions/' . $match . '</code>',
+                '<code>extensions/' . $e->getAdditional()->name . '</code>'
+            )), array('class' => 'message info'))
+        );
 
-    $button = new XMLElement('button', __('Rename folder'));
-    $button->setAttributeArray(array(
-        'name' => 'action[rename]',
-        'class' => 'button',
-        'type' => 'submit',
-        'accesskey' => 's'
-    ));
-    $actions->appendChild($button);
-} else {
-    $div->appendChild(
-        new XMLElement('p', __('You can try uninstalling the extension to continue, or you might want to ask on the forums'))
-    );
+        $button = new XMLElement('button', __('Rename folder'));
+        $button->setAttributeArray(array(
+            'name' => 'action[rename]',
+            'class' => 'button',
+            'type' => 'submit',
+            'accesskey' => 's'
+        ));
+        $actions->appendChild($button);
+    } else {
+        if ($author->isDeveloper()) {
+            $divInner->appendChild(
+                new XMLElement('p', __('You can try uninstalling the extension to continue, or you might want to ask on the forums'), array('class' => 'message info'))
+            );
+        } else {
+            $divInner->appendChild(
+                new XMLElement('p', __('Please contact the site administrator.'), array('class' => 'message info'))
+            );
+        }
+    }
 }
 
 // Add XSRF token to form's in the backend
 if (Symphony::Engine()->isXSRFEnabled()) {
-    $form->prependChild(XSRF::formToken());
+    #$form->prependChild(XSRF::formToken());
 }
 
-$div->appendChild($form);
+// Intentionally no automatic recovery actions are provided here.
+// Renaming extension directories or uninstalling missing extensions via the
+// web interface can cause unexpected side effects. The administrator
+// should restore the extension files or uninstall the extension manually
+// after checking its dependencies.
+if ($author !== null) {
+    if ($author->isDeveloper()) {
+        #$divInner->appendChild($form);
+    }
+}
 
-$Page->Body->appendChild($div);
+$div->appendChild($divInner);
+
+$main->appendChild($div);
+
+$Page->Body->appendChild($main);
 
 $output = $Page->generate();
 echo $output;

--- a/symphony/template/usererror.xslt.php
+++ b/symphony/template/usererror.xslt.php
@@ -6,10 +6,15 @@ $Page->Html->setElementStyle('html');
 
 $Page->Html->setDTD('<!DOCTYPE html>');
 $Page->Html->setAttribute('lang', 'en');
-#$Page->addElementToHead(new XMLElement('meta', null, array('http-equiv' => 'Content-Type', 'content' => 'text/html; charset=UTF-8')), 0);
+$Page->Html->setAttribute('dir', 'ltr');
+$Page->Html->setAttribute('data-type', 'xslt');
 $Page->addElementToHead(new XMLElement('meta', null, array('charset' => 'UTF-8')), 0);
-$Page->addElementToHead(new XMLElement('meta', null, array('name' => 'viewport', 'content' => 'width=device-width, initial-scale=1')), 1);
-$Page->addStylesheetToHead(ASSETS_URL . '/css/symphony.min.css', 'screen', null, false);
+$Page->addElementToHead(new XMLElement('meta', null, array('name' => 'robots', 'content' => 'noindex')), 1);
+$Page->addElementToHead(new XMLElement('meta', null, array('name' => 'viewport', 'content' => 'width=device-width, initial-scale=1')), 2);
+$Page->addElementToHead(new XMLElement('meta', null, array('name' => 'color-scheme', 'content' => 'dark light')), 3);
+$Page->addStylesheetToHead(ASSETS_URL . '/css/pico.min.css', 'screen', null, false, true);
+$Page->addStylesheetToHead(ASSETS_URL . '/css/pico-error.css', 'screen', null, false, true);
+$Page->addStylesheetToHead(ASSETS_URL . '/css/pico-messages.css', 'screen', null, false, true);
 
 $Page->setHttpStatus($e->getHttpStatusCode());
 $Page->addHeaderToPage('Content-Type', 'text/html; charset=UTF-8');
@@ -17,254 +22,32 @@ $Page->addHeaderToPage('Symphony-Error-Type', 'xslt');
 
 $Page->setTitle(__('%1$s &ndash; %2$s', array(__('Symphony'), __('XSLT Processing Error'))));
 $Page->Body->setAttribute('id', 'error');
+$Page->Body->setAttribute('class', 'template-generic');
 
+$main = new XMLElement('main', null, array('class' => 'container errorpage'));
+$main->appendChild(new XMLElement('h1', __('Symphony')));
 $div = new XMLElement('div', null, array('class' => 'frame'));
+$divInner = new XMLElement('div', null, array('class' => 'inner'));
+$divInner->appendChild(new XMLElement('h2', __('XSLT Processing Error')));
+$divInner->appendChild(new XMLElement('p', __('This page could not be rendered due to the following XSLT processing errors:'), array('class' => 'message invalid')));
+
+$errors = $e->getAdditional()->proc->getError(true, true);
+
 $ul = new XMLElement('ul');
-$li = new XMLElement('li');
-$li->appendChild(new XMLElement('h1', __('XSLT Processing Error')));
-$li->appendChild(new XMLElement('p', __('This page could not be rendered due to the following XSLT processing errors:')));
-$ul->appendChild($li);
 
-$errors_grouped = array();
-
-list($key, $val) = $e->getAdditional()->proc->getError(false, true);
-
-do {
-    if (preg_match('/^loadXML\(\)/i', $val['message']) && preg_match_all('/line:\s+(\d+)/i', $val['message'], $matches)) {
-        $errors_grouped['xml'][] = array('line'=>$matches[1][0], 'raw'=>$val);
-    } elseif (preg_match_all('/pages\/([^.\/]+\.xsl)\s+line\s+(\d+)/i', $val['message'], $matches) || preg_match_all('/pages\/([^.\/]+\.xsl):(\d+):/i', $val['message'], $matches)) {
-        $errors_grouped['page'][$matches[1][0]][] = array('line'=>$matches[2][0], 'raw'=>$val);
-    } elseif (preg_match_all('/utilities\/([^.\/]+\.xsl)\s+line\s+(\d+)/i', $val['message'], $matches)) {
-        $errors_grouped['utility'][$matches[1][0]][] = array('line'=>$matches[2][0], 'raw'=>$val);
-    } else {
-        $val['parts'] = explode(' ', $val['message'], 3);
-        $errors_grouped['general'][] = $val;
-    }
-} while (list($key, $val) = $e->getAdditional()->proc->getError());
-
-$query_string = General::sanitize($Page->__buildQueryString());
-
-if (strlen(trim($query_string)) > 0) {
-    $query_string = "&amp;{$query_string}";
+foreach ($errors as $error) {
+    $li = new XMLElement('li');
+    $li->setValue('<code>' . htmlspecialchars($error['message'], ENT_QUOTES, 'UTF-8') . '</code>');
+    $ul->appendChild($li);
 }
 
-foreach ($errors_grouped as $group => $data) {
-    switch ($group) {
-        case 'general':
-            $error = new XMLElement('li', '<header class="frame-header">' . __('General') . '<a class="debug" href="?debug' . $query_string .'" title="' . __('Show debug view') . '">' . __('Debug') . '</a></header>');
-            $content = new XMLElement('div', null, array('class' => 'content'));
-            $list = new XMLElement('ul');
-            $file = null;
-            $line = null;
+$divInner->appendChild($ul);
 
-            foreach ($data as $index => $e) {
+$div->appendChild($divInner);
 
-                // Highlight error
-                $class = array();
-                if (isset($data[$index + 1]['message']) && strpos($data[$index + 1]['message'], '^') !== false) {
-                    $class = array('class' => 'error');
-                }
+$main->appendChild($div);
 
-                // Don't show markers
-                if (strpos($e['message'], '^') === false) {
-                    $parts = explode('(): ', $e['message']);
-
-                    // Function
-                    preg_match('/(.*)\:(\d+)\:/', $e['parts'][1], $current);
-                    if ($data[$index - 1]['parts'][0] != $e['parts'][0] || (strpos($data[$index - 1]['message'], '^') !== false && $data[$index - 2]['message'] != $data[$index + 1]['message'])) {
-                        $list->appendChild(
-                            new XMLElement(
-                                'li',
-                                '<code><em>' . $e['parts'][0] . ' ' . $current[1] . '</em></code>'
-                            )
-                        );
-                    }
-
-                    // Store current file and line
-                    if (count($current) > 2) {
-                        $file = $current[1];
-                        $line = $current[2];
-                    }
-
-                    // Error
-                    if (!empty($class)) {
-                        if (isset($data[$index + 3]) && !empty($parts[1]) && strpos($data[$index + 3]['message'], $parts[1]) === false) {
-                            $position = explode('(): ', $data[$index + 1]['message']);
-                            $length = max(0, strlen($position[1]) - 1);
-                            $list->appendChild(
-                                new XMLElement(
-                                    'li',
-                                    '<code>&#160;&#160;&#160;&#160;' . str_replace(' ', '&#160;', trim(htmlspecialchars(substr($parts[1], 0, $length))) . '<b>' . htmlspecialchars(substr($parts[1], $length, 1)) . '</b>' . htmlspecialchars(substr($parts[1], $length + 1))) . '</code>',
-                                    $class
-                                )
-                            );
-
-                            if (isset($file, $line)) {
-                                // Show in debug
-                                $filename = explode(WORKSPACE . '/', $file);
-                                $list->appendChild(
-                                    new XMLElement(
-                                        'li',
-                                        '<code>&#160;&#160;&#160;&#160;<a href="?debug=/workspace/' . $filename[1] . '#line-' . $line .'" title="' . __('Show debug view for %s', array($filename[1])) . '">' . __('Show line %d in debug view', array($line)) . '</a></code>'
-                                    )
-                                );
-                            }
-                        }
-
-                        // Message
-                    } else {
-                        $list->appendChild(
-                            new XMLElement(
-                                'li',
-                                '<code>&#160;&#160;&#160;&#160;' . (strpos($e['parts'][1], '/') !== 0 ? $e['parts'][1] . ' ' : '') . str_replace(' ', '&#160;', $e['parts'][2]) . '</code>'
-                            )
-                        );
-                    }
-                }
-            }
-
-            $content->appendChild($list);
-            $error->appendChild($content);
-            $ul->appendChild($error);
-
-            break;
-        case 'page':
-            foreach ($data as $filename => $errors) {
-                $error = new XMLElement('li', '<header class="frame-header">' . $filename . '<a class="debug" href="?debug=/workspace/pages/' .  $filename . $query_string .'" title="' . __('Show debug view') . '">' . __('Debug') . '</a></header>');
-                $content = new XMLElement('div', null, array('class' => 'content'));
-                $list = new XMLElement('ul');
-
-                foreach ($errors as $e) {
-                    if (!is_array($e)) {
-                        continue;
-                    }
-
-                    $parts = explode('(): ', $e['raw']['message']);
-
-                    $list->appendChild(
-                        new XMLElement(
-                            'li',
-                            '<code><em>' . $parts[0] . '():</em></code>'
-                        )
-                    );
-                    $list->appendChild(
-                        new XMLElement(
-                            'li',
-                            '<code>&#160;&#160;&#160;&#160;' . $parts[1] . '</code>'
-                        )
-                    );
-                    $list->appendChild(
-                        new XMLElement(
-                            'li',
-                            '<code>&#160;&#160;&#160;&#160;<a href="?debug=/workspace/pages/' . $filename . $query_string . '#line-' . $e['line'] .'" title="' . __('Show debug view for %s', array($filename)) . '">' . __('Show line %d in debug view', array($e['line'])) . '</a></code>'
-                        )
-                    );
-                }
-
-                $content->appendChild($list);
-                $error->appendChild($content);
-                $ul->appendChild($error);
-            }
-
-            break;
-        case 'utility':
-            foreach ($data as $filename => $errors) {
-                $error = new XMLElement('li', '<header class="frame-header">' . $filename . '<a class="debug" href="?debug=/workspace/utilities/' .  $filename . $query_string .'" title="' . __('Show debug view') . '">' . __('Debug') . '</a></header>');
-                $content = new XMLElement('div', null, array('class' => 'content'));
-                $list = new XMLElement('ul');
-
-                foreach ($errors as $e) {
-                    if (!is_array($e)) {
-                        continue;
-                    }
-
-                    $parts = explode('(): ', $e['raw']['message']);
-
-                    $list->appendChild(
-                        new XMLElement(
-                            'li',
-                            '<code><em>' . $parts[0] . '():</em></code>'
-                        )
-                    );
-                    $list->appendChild(
-                        new XMLElement(
-                            'li',
-                            '<code>&#160;&#160;&#160;&#160;' . $parts[1] . '</code>'
-                        )
-                    );
-                    $list->appendChild(
-                        new XMLElement(
-                            'li',
-                            '<code>&#160;&#160;&#160;&#160;<a href="?debug=/workspace/utilities/' .  $filename . $query_string . '#line-' . $e['line'] .'" title="' . __('Show debug view for %s', array($filename)) . '">' . __('Show line %d in debug view', array($e['line'])) . '</a></code>'
-                        )
-                    );
-                }
-
-                $content->appendChild($list);
-                $error->appendChild($content);
-                $ul->appendChild($error);
-            }
-
-            break;
-        case 'xml':
-            foreach ($data as $filename => $errors) {
-                $error = new XMLElement('li', '<header class="frame-header">XML <a class="button" href="?debug=xml' . $query_string .'" title="' . __('Show debug view') . '">' . __('Debug') . '</a></header>');
-                $content = new XMLElement('div', null, array('class' => 'content'));
-                $list = new XMLElement('ul');
-
-                foreach ($errors as $e) {
-                    if (!is_array($e)) {
-                        continue;
-                    }
-
-                    $parts = explode('(): ', $e['message']);
-
-                    $list->appendChild(
-                        new XMLElement(
-                            'li',
-                            '<code><em>' . $parts[0] . '():</em></code>'
-                        )
-                    );
-                    $list->appendChild(
-                        new XMLElement(
-                            'li',
-                            '<code>&#160;&#160;&#160;&#160;' . $parts[1] . '</code>'
-                        )
-                    );
-
-                    if (strpos($e['file'], WORKSPACE) !== false) {
-                        // The line in the exception is where it was thrown, it's
-                        // useless for the ?debug view. This gets the line from
-                        // the ?debug page.
-                        preg_match('/:\s(\d+)$/', $parts[1], $line);
-
-                        $list->appendChild(
-                            new XMLElement(
-                                'li',
-                                '<code>&#160;&#160;&#160;&#160;<a href="?debug=xml' . $query_string . '#line-' . $line[1] .'" title="' . __('Show debug view for %s', array($filename)) . '">' . __('Show line %d in debug view', array($line[1])) . '</a></code>'
-                            )
-                        );
-                    } else {
-                        $list->appendChild(
-                            new XMLElement(
-                                'li',
-                                '<code>&#160;&#160;&#160;&#160;' . $e['file'] . ':' . $e['line']. '</code>'
-                            )
-                        );
-                    }
-                }
-
-                $content->appendChild($list);
-                $error->appendChild($content);
-                $ul->appendChild($error);
-            }
-
-            break;
-    }
-}
-
-$div->appendChild($ul);
-$Page->Body->appendChild($div);
+$Page->Body->appendChild($main);
 
 print $Page->generate();
 


### PR DESCRIPTION
- Modernize all Symphony error templates with Pico CSS, similar to the updated Login UI design.
- Add placeholder {VERSION} support for asset URLs in error templates.
- Fix XSLT error template handling for PHP 8 compatibility.
- Remove automatic rename and uninstall actions from the error template `missing_extension` to prevent unintended changes to the system state.