### PR TITLE
Prevent POST resubmission on generic error pages

### DIFF
--- a/symphony/template/usererror.generic.php
+++ b/symphony/template/usererror.generic.php
@@ -17,6 +17,7 @@ $Page->addElementToHead(new XMLElement('meta', null, array('name' => 'color-sche
 $Page->addStylesheetToHead(ASSETS_URL . '/css/pico.min.css', 'screen', null, false, true);
 $Page->addStylesheetToHead(ASSETS_URL . '/css/pico-error.css', 'screen', null, false, true);
 $Page->addStylesheetToHead(ASSETS_URL . '/css/pico-messages.css', 'screen', null, false, true);
+$Page->addScriptToHead(ASSETS_URL . '/js/usererror-generic.js', null, false, true, false);
 
 $Page->setHttpStatus($e->getHttpStatusCode());
 $Page->addHeaderToPage('Content-Type', 'text/html; charset=UTF-8');


### PR DESCRIPTION
- Add a browser history state reset to the generic error template to prevent accidental POST resubmission after reloading error pages.

- This avoids unintended repeated form submissions on banned and blacklisted error pages until the affected flows are migrated to a full Post/Redirect/Get pattern.