### PR TITLE
Improved: Invalidate PHP OPcache after writing PHP files

### DIFF
--- a/symphony/lib/toolkit/class.general.php
+++ b/symphony/lib/toolkit/class.general.php
@@ -1105,6 +1105,19 @@ class General
             return true;
         }
 
+        // File system informations (file_exists, filemtime, etc.)
+        clearstatcache(true, $file);
+
+        // Discard PHP bytecode
+        $extension = strtolower(pathinfo($file, PATHINFO_EXTENSION));
+
+        if (
+            $extension === 'php'
+            && function_exists('opcache_invalidate')
+        ) {
+            @opcache_invalidate($file, true);
+        }
+
         return true;
     }
 


### PR DESCRIPTION
Historically, Symphony wrote PHP files (e.g. configuration and templates) directly to disk, where subsequent requests immediately loaded the updated content. At that time, PHP was commonly executed without a persistent opcode cache.

Today, most production environments run PHP via PHP-FPM/FastCGI with OPcache enabled. Newly written PHP files may therefore continue to use cached bytecode until OPcache detects the file change, resulting in stale configuration values or outdated templates being loaded immediately after writing.

General::writeFile() now clears the PHP stat cache and invalidates the OPcache entry for written PHP files, ensuring updated files are available immediately without waiting for automatic cache revalidation.

Additionally, the Email Template Manager extension now uses General::writeFile() instead of direct file_put_contents() so it benefits from the same central file handling and cache invalidation logic.