### PR TITLE
Improved: Redirect unauthenticated requests via Symphony's login page

### DIFF
--- a/symphony/content/content.login.php
+++ b/symphony/content/content.login.php
@@ -73,6 +73,12 @@ class contentLogin extends HTMLPage
 
     public function view()
     {
+        // First, redirect unauthenticated requests to the dedicated login page
+        if (isset($this->_context['redirect'])) {
+            $redirectUrl = SYMPHONY_URL . General::sanitize($this->_context['redirect']);
+            redirect(SYMPHONY_URL . '/login/?redirect_to=' . rawurlencode($redirectUrl));
+        }
+
         if (isset($this->_context[0]) && in_array(strlen($this->_context[0]), array(6, 8, 16))) {
             if (!$this->__loginFromToken($this->_context[0])) {
                 if (Administration::instance()->isLoggedIn()) {
@@ -91,7 +97,21 @@ class contentLogin extends HTMLPage
 
         $siteName = new XMLElement('h1', __('Symphony'));
 
-        $this->Form = Widget::Form(SYMPHONY_URL . '/login/', 'post', 'frame');
+        $redirect_to = null;
+        // Validating the `redirect_to` URL against SYMPHONY_URL
+        // and URL and discarding invalid or external redirect targets
+        if (
+            isset($_GET['redirect_to'])
+            && (
+                strpos($_GET['redirect_to'], SYMPHONY_URL) === 0
+                || strpos($_GET['redirect_to'], URL) === 0
+            )
+        ) {
+            $redirect_to = General::sanitize($_GET['redirect_to']);
+            $this->Form = Widget::Form(SYMPHONY_URL . '/login/?redirect_to=' . rawurlencode($redirect_to), 'post', 'frame');
+        } else {
+            $this->Form = Widget::Form(SYMPHONY_URL . '/login/', 'post', 'frame');
+        }
 
         $divInner = new XMLElement('div', null, array('class' => 'inner'));
 
@@ -281,9 +301,9 @@ class contentLogin extends HTMLPage
             $div->appendChild($p);
             $this->Form->appendChild($div);
 
-            if (isset($this->_context['redirect'])) {
+            if ($redirect_to !== null) {
                 $this->Form->appendChild(
-                    Widget::Input('redirect', SYMPHONY_URL . General::sanitize($this->_context['redirect']), 'hidden')
+                    Widget::Input('redirect', $redirect_to, 'hidden')
                 );
             }
         }

--- a/symphony/lib/toolkit/class.frontendpage.php
+++ b/symphony/lib/toolkit/class.frontendpage.php
@@ -683,11 +683,14 @@ class FrontendPage extends XSLTPage
             $row = PageManager::fetchPageByType('401');
 
             if (empty($row)) {
-                Frontend::instance()->throwCustomError(
-                    __('Please login to view this page.') . ' <a href="' . SYMPHONY_URL . '/login/">' . __('Take me to the login page') . '</a>.',
-                    __('Unauthorized'),
-                    Page::HTTP_STATUS_UNAUTHORIZED
-                );
+                // Pass the page's URL as a redirect parameter to the Symphony
+                // login page instead of displaying an error page.
+                redirect(SYMPHONY_URL . '/login/?redirect_to=' . rawurlencode(URL . $this->_page));
+#                Frontend::instance()->throwCustomError(
+#                    __('Please login to view this page.') . ' <a href="' . SYMPHONY_URL . '/login/">' . __('Take me to the login page') . '</a>.',
+#                    __('Unauthorized'),
+#                    Page::HTTP_STATUS_UNAUTHORIZED
+#                );
             }
 
             $row['type'] = PageManager::fetchPageTypes($row['id']);


### PR DESCRIPTION
The authentication flow has been streamlined by redirecting unauthenticated requests for backend pages and protected  frontend pages of type admin to Symphony's dedicated login page (`/symphony/login/`).

A redirect mechanism was already partially implemented in `content.login.php`, but it was never completed because the login form was rendered directly on the requested page. As a result, the existing hidden redirect field was never populated with the intended target URL.

This change completes the original implementation by:

- redirecting unauthenticated requests to the dedicated login page,
- preserving the originally requested URL via `redirect_to`,
- validating the `redirect_to` URL against `SYMPHONY_URL` or `URL` and discarding invalid or external redirect targets,
- keeping the redirect target across failed login attempts, and
- returning users to their originally requested page after successful authentication.

Bookmarked backend URLs and protected frontend pages continue to work seamlessly after authentication through the redirect mechanism.