### PR TITLE
Improved: Image MIME types for the upload field

### DIFF
--- a/symphony/lib/toolkit/fields/field.upload.php
+++ b/symphony/lib/toolkit/fields/field.upload.php
@@ -13,9 +13,14 @@ class FieldUpload extends Field implements ExportableField, ImportableField
         'image/gif',
         'image/jpg',
         'image/jpeg',
-        'image/pjpeg',
         'image/png',
-        'image/x-png'
+        'image/webp',
+        // AVIF uses the HEIF container format.
+        // Some image libraries report valid AVIF files as image/heif.
+        // Keep this MIME type to fully support AVIF uploads.
+        'image/avif',
+        'image/heif',
+        'image/bmp'
     );
 
     public function __construct()


### PR DESCRIPTION
- The following MIME types have been added: `image/webp`, `image/bmp`¹, `image/avif`, and `image/heif`². This ensures that the metadata for the images (image width and height) extracted and stored.
- The following legacy MIME types have been removed: `image/pjpeg` (progressive JPEG) and `image/x-png`.

Note ¹: BMP images must be saved in Windows Bitmap V3 / 24-bit format. Some newer BMP variants (for example, 32-bit BMP with alpha channels) are not supported by PHP GD's BMP decoder.
Note ²: AVIF uses the HEIF container format. Some image libraries report valid AVIF files as `image/heif`. The MIME type must be included to fully support AVIF uploads.